### PR TITLE
Switch /analytics to Market Terminal UI + wire top actions

### DIFF
--- a/frontend/src/pages/BlackboxPage.tsx
+++ b/frontend/src/pages/BlackboxPage.tsx
@@ -1,102 +1,85 @@
 // Blackbox Page Component
-// Signal Intelligence Terminal - Main trading interface
+// Market Terminal - Analytics interface inside AppLayout
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { PriceChart } from '../components/blackbox/PriceChart';
 import { OrderBookPanel } from '../components/blackbox/OrderBookPanel';
 import { TimeSalesPanel } from '../components/blackbox/TimeSalesPanel';
 import { AgentLeaderboard } from '../components/blackbox/AgentLeaderboard';
 import { SignalInterceptsPanel } from '../components/blackbox/SignalInterceptsPanel';
-import { LiveRibbon } from '../components/marketplace/LiveRibbon';
-import { TimelineGrid } from '../components/blackbox/TimelineGrid';
-import { WarChestGrid } from '../components/blackbox/WarChestGrid';
 import {
   useBlackboxChart,
   useOrderBook,
   useTimeSales,
   useAgentLeaderboard,
-  useTimelines,
-  useWarChest,
   useIntercepts,
-  useBlackboxRibbon,
-  useSystemStatus,
 } from '../hooks/useBlackbox';
+import { useRegisterTopActionBarActions } from '../contexts/TopActionBarActionsContext';
 import type { Timeframe } from '../types/blackbox';
-
-type TabType = 'markets' | 'intercepts' | 'timeline' | 'warchest';
 
 export function BlackboxPage() {
   const [timeframe, setTimeframe] = useState<Timeframe>('15m');
-  const [activeTab, setActiveTab] = useState<TabType>('markets');
+  
+  // Panel state
+  const [alertPanelOpen, setAlertPanelOpen] = useState(false);
+  const [comparePanelOpen, setComparePanelOpen] = useState(false);
+  const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
+  
+  // Refs for backdrop click handling
+  const alertPanelRef = useRef<HTMLDivElement>(null);
+  const comparePanelRef = useRef<HTMLDivElement>(null);
+  const settingsPanelRef = useRef<HTMLDivElement>(null);
 
   // Data hooks
   const { candles, currentPrice, indicators } = useBlackboxChart(timeframe);
   const orderBook = useOrderBook();
   const trades = useTimeSales();
   const { agents, searchQuery, setSearchQuery } = useAgentLeaderboard();
-  const timelines = useTimelines();
-  const warChest = useWarChest();
   const intercepts = useIntercepts();
-  const ribbonEvents = useBlackboxRibbon();
-  
-  // Transform blackbox ribbon events to marketplace format
-  const ribbonEventsForComponent = ribbonEvents.map(event => ({
-    type: event.type === 'market' ? 'fork' as const : event.type === 'shield' ? 'wing' as const : event.type,
-    title: `${event.agent}: ${event.action}`,
-    time: event.timestamp.toLocaleTimeString('en-US', { hour12: false }),
-    theatre: event.theatre,
-  }));
 
-  const { latency } = useSystemStatus();
+  // Register TopActionBar actions
+  useRegisterTopActionBarActions({
+    onAlert: () => {
+      setAlertPanelOpen(prev => !prev);
+      setComparePanelOpen(false);
+      setSettingsPanelOpen(false);
+    },
+    onCompare: () => {
+      setComparePanelOpen(prev => !prev);
+      setAlertPanelOpen(false);
+      setSettingsPanelOpen(false);
+    },
+    onRefresh: () => {
+      // Refresh data - hooks will auto-refresh
+      console.log('Refresh analytics data');
+    },
+  });
 
-  const tabs: { id: TabType; label: string }[] = [
-    { id: 'markets', label: 'Market Terminal' },
-    { id: 'intercepts', label: 'Signal Intercepts' },
-    { id: 'timeline', label: 'Timeline Health' },
-    { id: 'warchest', label: 'War Chest' },
-  ];
+  // Close panels on Escape key
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setAlertPanelOpen(false);
+        setComparePanelOpen(false);
+        setSettingsPanelOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   return (
-    <div className="container" style={{ height: '100vh', display: 'flex', flexDirection: 'column', background: 'var(--bg-app)' }}>
-      {/* Live Intel Ribbon */}
-      <LiveRibbon events={ribbonEventsForComponent} />
-
-      {/* Tab Navigation */}
-      <div className="tab-nav" style={{ flexShrink: 0, display: 'flex', gap: 8, padding: '12px 24px', background: 'var(--bg-app)', borderBottom: '1px solid var(--border-outer)' }}>
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            className={`tab-btn ${activeTab === tab.id ? 'active' : ''}`}
-            onClick={() => setActiveTab(tab.id)}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '8px 16px',
-              background: activeTab === tab.id ? 'var(--bg-panel)' : 'transparent',
-              border: activeTab === tab.id ? '1px solid var(--border-outer)' : '1px solid transparent',
-              borderRadius: 20,
-              color: activeTab === tab.id ? 'var(--text-primary)' : 'var(--text-secondary)',
-              fontSize: 12,
-              fontWeight: 500,
-              cursor: 'pointer',
-              transition: 'all 0.2s ease',
-            }}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Main Content */}
-{activeTab === 'markets' && (
-        <main className="tab-content active" style={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-          <div className="grid-layout" style={{ display: 'grid', gridTemplateColumns: '1fr 340px', gap: 16, height: '100%', padding: 16, overflow: 'hidden' }}>
+    <div className="h-full flex flex-col" style={{ backgroundColor: '#0B0C0E', color: '#F1F5F9' }}>
+      
+      {/* Market Terminal Grid */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        <div className="flex-1 min-h-0 flex flex-col p-4 overflow-hidden">
+          
+          {/* Main Grid Layout */}
+          <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
             
-            {/* Left Column: Chart + Bottom Split */}
-            <div className="chart-section" style={{ display: 'flex', flexDirection: 'column', gap: 16, minWidth: 0, overflow: 'hidden' }}>
-              
-              {/* Chart */}
+            {/* Top Section: Price Chart */}
+            <div className="flex-shrink-0" style={{ height: '40%', minHeight: 200 }}>
               <PriceChart
                 candles={candles}
                 currentPrice={currentPrice}
@@ -104,113 +87,139 @@ export function BlackboxPage() {
                 timeframe={timeframe}
                 onTimeframeChange={setTimeframe}
               />
-
-              {/* Bottom Split */}
-              <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, minHeight: 0, overflow: 'hidden' }}>
+            </div>
+            
+            {/* Bottom Section: Split Grid */}
+            <div className="flex-1 min-h-0 flex flex-row gap-4 mt-4 overflow-hidden">
+              
+              {/* Left: Time & Sales */}
+              <div className="flex-1 min-w-0 overflow-hidden" style={{ minWidth: 0 }}>
                 <TimeSalesPanel trades={trades} />
+              </div>
+              
+              {/* Center: Agent Performance */}
+              <div className="flex-1 min-w-0 overflow-hidden" style={{ minWidth: 0 }}>
                 <AgentLeaderboard agents={agents} searchQuery={searchQuery} onSearchChange={setSearchQuery} />
               </div>
-            </div>
-
-            {/* Right Sidebar: Order Book + Intercepts */}
-            <div className="sidebar-section" style={{ display: 'flex', flexDirection: 'column', gap: 16, minWidth: 0, overflow: 'hidden' }}>
-              <OrderBookPanel orderBook={orderBook} currentPrice={currentPrice} />
-              <SignalInterceptsPanel intercepts={intercepts} />
-            </div>
-          </div>
-        </main>
-      )}
-
-      {activeTab === 'intercepts' && (
-        <main className="tab-content active" style={{ flex: 1, overflow: 'auto' }}>
-          <div className="panel" style={{ margin: 16, padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 32px)' }}>
-            <div className="panel-header">
-              <span className="panel-title">SIGNAL LOGS</span>
-            </div>
-            <div className="data-list" style={{ flex: 1, overflow: 'auto' }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                <thead>
-                  <tr style={{ borderBottom: '1px solid var(--border-outer)' }}>
-                    <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>TIME</th>
-                    <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>TYPE</th>
-                    <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>THEATRE</th>
-                    <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>AGENT</th>
-                    <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>ACTION</th>
-                    <th style={{ padding: '8px 16px', textAlign: 'right', fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase' }}>VOLUME</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {intercepts.map((intercept, i) => (
-                    <tr key={i} style={{ borderBottom: '1px solid var(--border-inner)' }}>
-                      <td className="mono" style={{ padding: '8px 16px', fontSize: 11, color: 'var(--text-muted)' }}>
-                        {intercept.timestamp.toISOString().substr(11, 8)}
-                      </td>
-                      <td style={{ padding: '8px 16px' }}>
-                        <span className={`ribbon-tag ${intercept.severity === 'critical' ? 'sabotage' : intercept.severity === 'warning' ? 'market' : intercept.severity === 'success' ? 'shield' : 'market'}`} style={{ fontSize: 9, fontWeight: 700, padding: '2px 6px', borderRadius: 4 }}>
-                          {intercept.severity.toUpperCase()}
-                        </span>
-                      </td>
-                      <td style={{ padding: '8px 16px', fontSize: 11 }}>{intercept.theatre || '—'}</td>
-                      <td style={{ padding: '8px 16px', fontSize: 11 }}>{intercept.agent || '—'}</td>
-                      <td style={{ padding: '8px 16px', fontSize: 11, color: 'var(--text-secondary)' }}>{intercept.title}</td>
-                      <td className="numeric mono" style={{ padding: '8px 16px', fontSize: 11, textAlign: 'right' }}>—</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              
+              {/* Right Sidebar: Order Book + Signal Intercepts */}
+              <div className="w-80 flex-shrink-0 flex flex-col gap-4 overflow-hidden">
+                <OrderBookPanel orderBook={orderBook} currentPrice={currentPrice} />
+                <SignalInterceptsPanel intercepts={intercepts} />
+              </div>
+              
             </div>
           </div>
-        </main>
-      )}
-
-      {activeTab === 'timeline' && (
-        <main className="tab-content active" style={{ flex: 1, overflow: 'auto' }}>
-          <TimelineGrid timelines={timelines} />
-        </main>
-      )}
-
-      {activeTab === 'warchest' && (
-        <main className="tab-content active" style={{ flex: 1, overflow: 'auto' }}>
-          <WarChestGrid items={warChest} />
-        </main>
-      )}
-
-      {/* Footer */}
-      <footer className="app-footer" style={{ flexShrink: 0, background: 'var(--bg-panel)', borderTop: '1px solid var(--border-outer)', padding: '4px 24px', display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--text-muted)' }}>
-        <div className="flex-center" style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-          <span><span className="live-dot" style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--status-success)', marginRight: 6 }}></span> System Optimal</span>
-          <span>Latency: {latency}ms</span>
         </div>
-        <div className="flex-center" style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-          <span>Echelon Protocol Inc.</span>
-          <span>Restricted Access</span>
-        </div>
-      </footer>
+      </div>
 
-      {/* CSS Animations */}
-      <style>{`
-        @keyframes pulse {
-          0% { opacity: 1; }
-          50% { opacity: 0.5; }
-          100% { opacity: 1; }
-        }
-        .tab-btn:hover {
-          color: var(--text-primary) !important;
-          background: var(--bg-card) !important;
-        }
-        .nav-btn:hover {
-          border-color: var(--text-muted) !important;
-          color: var(--text-primary) !important;
-        }
-        .action-btn:hover {
-          border-color: var(--text-muted) !important;
-          color: var(--text-primary) !important;
-        }
-        ::-webkit-scrollbar { width: 6px; height: 6px; }
-        ::-webkit-scrollbar-track { background: var(--bg-app); }
-        ::-webkit-scrollbar-thumb { background: var(--border-outer); border-radius: 3px; }
-        ::-webkit-scrollbar-thumb:hover { background: var(--slate-700); }
-      `}</style>
+      {/* Alert Panel Backdrop */}
+      {alertPanelOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          style={{ background: 'rgba(0,0,0,0.3)' }}
+          onClick={() => setAlertPanelOpen(false)}
+        />
+      )}
+
+      {/* Alert Panel */}
+      {alertPanelOpen && (
+        <div
+          ref={alertPanelRef}
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: '#151719',
+            border: '1px solid #26292E',
+          }}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b" style={{ background: '#121417', borderColor: '#26292E' }}>
+            <span className="text-sm font-semibold" style={{ color: '#F1F5F9' }}>Analytics Alerts</span>
+            <button
+              onClick={() => setAlertPanelOpen(false)}
+              className="p-1 rounded transition-colors"
+              style={{ color: '#64748B' }}
+            >
+              ✕
+            </button>
+          </div>
+          <div className="p-4 overflow-y-auto" style={{ maxHeight: 400 }}>
+            <p className="text-xs" style={{ color: '#64748B' }}>No alerts configured for analytics.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Compare Panel Backdrop */}
+      {comparePanelOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          style={{ background: 'rgba(0,0,0,0.3)' }}
+          onClick={() => setComparePanelOpen(false)}
+        />
+      )}
+
+      {/* Compare Panel */}
+      {comparePanelOpen && (
+        <div
+          ref={comparePanelRef}
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: '#151719',
+            border: '1px solid #26292E',
+          }}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b" style={{ background: '#121417', borderColor: '#26292E' }}>
+            <span className="text-sm font-semibold" style={{ color: '#F1F5F9' }}>Compare Theatres</span>
+            <button
+              onClick={() => setComparePanelOpen(false)}
+              className="p-1 rounded transition-colors"
+              style={{ color: '#64748B' }}
+            >
+              ✕
+            </button>
+          </div>
+          <div className="p-4 overflow-y-auto" style={{ maxHeight: 400 }}>
+            <p className="text-xs" style={{ color: '#64748B' }}>Select theatres to compare.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Settings Panel Backdrop */}
+      {settingsPanelOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          style={{ background: 'rgba(0,0,0,0.3)' }}
+          onClick={() => setSettingsPanelOpen(false)}
+        />
+      )}
+
+      {/* Settings Panel */}
+      {settingsPanelOpen && (
+        <div
+          ref={settingsPanelRef}
+          className="fixed top-[60px] right-6 w-80 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: '#151719',
+            border: '1px solid #26292E',
+          }}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b" style={{ background: '#121417', borderColor: '#26292E' }}>
+            <span className="text-sm font-semibold" style={{ color: '#F1F5F9' }}>Analytics Settings</span>
+            <button
+              onClick={() => setSettingsPanelOpen(false)}
+              className="p-1 rounded transition-colors"
+              style={{ color: '#64748B' }}
+            >
+              ✕
+            </button>
+          </div>
+          <div className="p-4">
+            <p className="text-xs" style={{ color: '#64748B' }}>Settings panel stub.</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,9 +1,9 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
 import { FieldKit } from './components/fieldkit/FieldKit';
-import { Blackbox } from './components/blackbox/Blackbox';
 import { TimelineDetailPage } from './pages/TimelineDetailPage';
 import { MarketplacePage } from './pages/MarketplacePage';
+import { BlackboxPage } from './pages/BlackboxPage';
 import { LaunchpadPage } from './pages/LaunchpadPage';
 import { LaunchpadDetailPage } from './pages/LaunchpadDetailPage';
 import { LaunchpadNewPage } from './pages/LaunchpadNewPage';
@@ -37,7 +37,7 @@ export const router = createBrowserRouter([
         path: 'analytics',
         element: (
           <ErrorBoundary>
-            <Blackbox />
+            <BlackboxPage />
           </ErrorBoundary>
         ),
       },


### PR DESCRIPTION
- Route /analytics now renders BlackboxPage (Market Terminal) instead of old Blackbox component
- BlackboxPage integrates with AppLayout (no duplicate header/footer)
- Register TopActionBar actions: alert, compare, refresh with proper panel toggle/close
- Panels close on backdrop click, Escape key, X button, or toggle button
- Remove old Analytics UI (Blackbox component) from /analytics route