### PR TITLE
fix: Resolve maximum update depth error (useSyncExternalStore snapsho…

### DIFF
--- a/frontend/src/demo/DemoEngine.tsx
+++ b/frontend/src/demo/DemoEngine.tsx
@@ -174,8 +174,8 @@ export function DemoEngine({ children }: { children: React.ReactNode }) {
     const carriers = ["VIPER", "SENTINEL", "ARCHON", "AMBASSADOR", "LEVIATHAN"];
 
     const seedBreaches = () => {
-      const existing = demoStore.getBreaches();
-      if (existing.active.length > 0 || existing.history.length > 0) return;
+      const existing = demoStore.getBreachesActive();
+      if (existing.length > 0) return;
 
       const active = [
         {
@@ -211,7 +211,7 @@ export function DemoEngine({ children }: { children: React.ReactNode }) {
     };
 
     const tickBreaches = () => {
-      const { active } = demoStore.getBreaches();
+      const active = demoStore.getBreachesActive();
 
       // Mutate existing breaches
       for (const b of active) {
@@ -238,7 +238,7 @@ export function DemoEngine({ children }: { children: React.ReactNode }) {
           sanity: Math.floor(randBetween(r, 30, 70)),
           status: "ACTIVE" as const,
         };
-        const { active: currActive, history } = demoStore.getBreaches();
+        const { active: currActive, history } = { active: demoStore.getBreachesActive(), history: demoStore.getBreachesHistory() };
         demoStore.setBreaches([...currActive, newBreach], history);
       }
 
@@ -264,7 +264,7 @@ export function DemoEngine({ children }: { children: React.ReactNode }) {
     const formats: Array<"PyTorch (.pt)" | "ROS Bag (.bag)" | "TFRecord (.tfrecord)" | "JSON (Canonical)"> = ["PyTorch (.pt)", "ROS Bag (.bag)", "TFRecord (.tfrecord)", "JSON (Canonical)"];
 
     const seedExports = () => {
-      const { active } = demoStore.getExports();
+      const active = demoStore.getExportsActive();
       if (active.length > 0) return;
 
       const newActive = [
@@ -309,7 +309,7 @@ export function DemoEngine({ children }: { children: React.ReactNode }) {
     };
 
     const tickExports = () => {
-      const { active } = demoStore.getExports();
+      const active = demoStore.getExportsActive();
 
       for (const x of active) {
         if (x.status === "PROCESSING") {

--- a/frontend/src/demo/demoStore.ts
+++ b/frontend/src/demo/demoStore.ts
@@ -279,8 +279,12 @@ export const demoStore = {
   },
 
   // --- Breaches ---
-  getBreaches() {
-    return { active: state.breachesActive, history: state.breachesHistory };
+  getBreachesActive() {
+    return state.breachesActive;
+  },
+
+  getBreachesHistory() {
+    return state.breachesHistory;
   },
 
   setBreaches(active: DemoBreach[], history: DemoBreachHistoryRow[]) {
@@ -312,8 +316,16 @@ export const demoStore = {
   },
 
   // --- Exports ---
-  getExports() {
-    return { active: state.exportsActive, partners: state.exportPartners, config: state.exportConfig };
+  getExportsActive() {
+    return state.exportsActive;
+  },
+
+  getExportPartners() {
+    return state.exportPartners;
+  },
+
+  getExportConfig() {
+    return state.exportConfig;
   },
 
   setExports(active: DemoExportJob[]) {

--- a/frontend/src/demo/hooks.ts
+++ b/frontend/src/demo/hooks.ts
@@ -8,10 +8,15 @@
 import { useEffect, useMemo, useSyncExternalStore } from "react";
 import { isDemoModeEnabled } from "./demoMode";
 import { demoStore } from "./demoStore";
+import type { DemoExportConfig } from "./demoStore";
 
 export function useDemoEnabled(): boolean {
   return isDemoModeEnabled();
 }
+
+// Constants for stable snapshots when demo is OFF
+const EMPTY_ARRAY: never[] = [];
+const EMPTY_CONFIG: DemoExportConfig = { samplingRate: 0.5, format: "PyTorch (.pt)", compression: "GZIP" };
 
 export function useDemoOutcome(
   marketId: string | number,
@@ -57,57 +62,119 @@ export function useDemoOutcome(
 export function useDemoPositions() {
   const enabled = useDemoEnabled();
 
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribePositions(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getPositions(), []);
-  const positions = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+    return (listener: () => void) => demoStore.subscribePositions(listener);
+  }, [enabled]);
 
-  return enabled ? positions : [];
+  const getSnapshot = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getPositions();
+  }, [enabled]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useDemoAgentFeed() {
   const enabled = useDemoEnabled();
 
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribeAgentFeed(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getAgentFeed(), []);
-  const feed = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+    return (listener: () => void) => demoStore.subscribeAgentFeed(listener);
+  }, [enabled]);
 
-  return enabled ? feed : [];
+  const getSnapshot = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getAgentFeed();
+  }, [enabled]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useDemoToasts() {
   const enabled = useDemoEnabled();
 
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribeToasts(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getToasts(), []);
-  const toasts = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+    return (listener: () => void) => demoStore.subscribeToasts(listener);
+  }, [enabled]);
 
-  return enabled ? toasts : [];
+  const getSnapshot = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getToasts();
+  }, [enabled]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 // --- New hooks for Launchpad, Breach Console, Export Console ---
 
 export function useDemoLaunchFeed() {
   const enabled = useDemoEnabled();
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribeLaunchFeed(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getLaunchFeed(), []);
-  const feed = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  return enabled ? feed : [];
+
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+    return (listener: () => void) => demoStore.subscribeLaunchFeed(listener);
+  }, [enabled]);
+
+  const getSnapshot = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getLaunchFeed();
+  }, [enabled]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export function useDemoBreaches() {
   const enabled = useDemoEnabled();
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribeBreaches(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getBreaches(), []);
-  const data = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  return enabled ? data : { active: [], history: [] };
+
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+return (listener: () => void) => demoStore.subscribeBreaches(listener);
+  }, [enabled]);
+
+  const getSnapshotActive = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getBreachesActive();
+  }, [enabled]);
+
+  const getSnapshotHistory = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getBreachesHistory();
+  }, [enabled]);
+
+  const active = useSyncExternalStore(subscribe, getSnapshotActive, getSnapshotActive);
+  const history = useSyncExternalStore(subscribe, getSnapshotHistory, getSnapshotHistory);
+
+  return { active, history };
 }
 
 export function useDemoExports() {
   const enabled = useDemoEnabled();
-  const subscribe = useMemo(() => (l: () => void) => demoStore.subscribeExports(l), []);
-  const getSnapshot = useMemo(() => () => demoStore.getExports(), []);
-  const data = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-  return enabled
-    ? data
-    : { active: [], partners: [], config: { samplingRate: 0.5, format: "PyTorch (.pt)", compression: "GZIP" as const } };
+
+  const subscribe = useMemo(() => {
+    if (!enabled) return () => () => {};
+    return (listener: () => void) => demoStore.subscribeExports(listener);
+  }, [enabled]);
+
+  const getSnapshotActive = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getExportsActive();
+  }, [enabled]);
+
+  const getSnapshotPartners = useMemo(() => {
+    if (!enabled) return () => EMPTY_ARRAY;
+    return () => demoStore.getExportPartners();
+  }, [enabled]);
+
+  const getSnapshotConfig = useMemo(() => {
+    if (!enabled) return () => EMPTY_CONFIG;
+    return () => demoStore.getExportConfig();
+  }, [enabled]);
+
+  const active = useSyncExternalStore(subscribe, getSnapshotActive, getSnapshotActive);
+  const partners = useSyncExternalStore(subscribe, getSnapshotPartners, getSnapshotPartners);
+  const config = useSyncExternalStore(subscribe, getSnapshotConfig, getSnapshotConfig);
+
+  return { active, partners, config };
 }


### PR DESCRIPTION
…t stability)

- Split getBreaches() into getBreachesActive() and getBreachesHistory()
- Split getExports() into getExportsActive(), getExportPartners(), getExportConfig()
- Make all demo hooks use conditional subscriptions with stable empty values
- useDemoToasts, useDemoPositions, useDemoAgentFeed return stable snapshots
- useDemoBreaches and useDemoExports use individual stable getters

The root cause was getBreaches() and getExports() returning new object references on every call, causing infinite render loops in useSyncExternalStore.