### PR TITLE
fix: solid overlay surfaces, standardized z-index, unified Launchpad …

### DIFF
--- a/frontend/src/components/ButlerWidget.tsx
+++ b/frontend/src/components/ButlerWidget.tsx
@@ -5,7 +5,7 @@ export function ButlerWidget() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="fixed bottom-24 md:bottom-6 right-4 md:right-6 z-[45]">
+    <div className="fixed bottom-24 md:bottom-6 right-4 md:right-6 z-[100]">
       {/* Expanded Panel */}
       {isExpanded && (
         <div className="mb-4 w-80 bg-[#0D0D0D] border border-purple-500/50 rounded-lg shadow-2xl overflow-hidden animate-in slide-in-from-bottom-4 duration-200">

--- a/frontend/src/components/agents/TaskAgentModal.tsx
+++ b/frontend/src/components/agents/TaskAgentModal.tsx
@@ -89,14 +89,14 @@ export function TaskAgentModal({ agent, isOpen, onClose }: TaskAgentModalProps) 
     <>
       {/* Glassmorphism Overlay */}
       <div 
-        className="fixed inset-0 bg-[#030305]/80 backdrop-blur-sm z-[9990]"
+        className="fixed inset-0 bg-[#030305]/80 backdrop-blur-sm z-[300]"
         style={{ pointerEvents: 'auto' }}
         onClick={onClose}
       />
       
       {/* Modal content */}
       <div 
-        className="fixed inset-0 z-[9995] flex items-center justify-center p-4 pointer-events-none"
+        className="fixed inset-0 z-[310] flex items-center justify-center p-4 pointer-events-none"
         onClick={(e) => {
           if (e.target === e.currentTarget) onClose();
         }}

--- a/frontend/src/components/blackbox/TaskForce.tsx
+++ b/frontend/src/components/blackbox/TaskForce.tsx
@@ -190,12 +190,12 @@ export function TaskForce() {
       {showCreateModal && (
         <>
           <div
-            className="fixed inset-0 bg-black/90 backdrop-blur-md z-[9990]"
+            className="fixed inset-0 bg-black/90 backdrop-blur-md z-[300]"
             onClick={() => setShowCreateModal(false)}
           />
           {/* Single scroll container (iOS-friendly) */}
           <div
-            className="fixed inset-0 z-[9995] overflow-y-scroll overscroll-contain p-4"
+            className="fixed inset-0 z-[310] overflow-y-scroll overscroll-contain p-4"
             style={{ WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' }}
           >
             <div className="min-h-full flex items-start justify-center py-8">

--- a/frontend/src/components/fieldkit/GhostForks.tsx
+++ b/frontend/src/components/fieldkit/GhostForks.tsx
@@ -284,11 +284,11 @@ export function GhostForks() {
       {/* Create Fork Modal */}
       {showCreateModal && (
         <div 
-          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-[300] p-4"
           onClick={() => setShowCreateModal(false)}
         >
           <div 
-            className="bg-terminal-panel border border-echelon-cyan/50 rounded-lg p-6 max-w-lg w-full"
+            className="bg-terminal-overlay border border-echelon-cyan/50 rounded-lg p-6 max-w-lg w-full"
             onClick={(e) => e.stopPropagation()}
           >
             <h3 className="text-echelon-cyan font-bold text-lg mb-4 flex items-center gap-2">

--- a/frontend/src/components/home/LaunchCardMini.tsx
+++ b/frontend/src/components/home/LaunchCardMini.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Database, ExternalLink } from 'lucide-react';
 import type { LaunchCard } from '../../types/launchpad';
+import { PHASE_COLORS, CATEGORY_COLORS, getQualityColor } from '../../constants/launchpad';
 
 /**
  * LaunchCardMini Props
@@ -11,45 +12,6 @@ export interface LaunchCardMiniProps {
 }
 
 /**
- * Get phase badge color and label
- */
-function getPhaseBadge(phase: LaunchCard['phase']): { bg: string; text: string; label: string } {
-  switch (phase) {
-    case 'draft':
-      return { bg: '#64748B', text: '#FFFFFF', label: 'DRAFT' };
-    case 'sandbox':
-      return { bg: '#F59E0B', text: '#FFFFFF', label: 'SANDBOX' };
-    case 'pilot':
-      return { bg: '#3B82F6', text: '#FFFFFF', label: 'PILOT' };
-    case 'graduated':
-      return { bg: '#10B981', text: '#FFFFFF', label: 'GRADUATED' };
-    case 'failed':
-      return { bg: '#EF4444', text: '#FFFFFF', label: 'FAILED' };
-  }
-}
-
-/**
- * Get category badge color
- */
-function getCategoryColor(category: LaunchCard['category']): string {
-  switch (category) {
-    case 'theatre':
-      return '#3B82F6';
-    case 'osint':
-      return '#8B5CF6';
-  }
-}
-
-/**
- * Get quality score color
- */
-function getQualityColor(score: number): string {
-  if (score >= 80) return '#10B981'; // emerald
-  if (score >= 60) return '#F59E0B'; // amber
-  return '#EF4444'; // crimson
-}
-
-/**
  * LaunchCardMini Component
  * 
  * Compact card displaying launch information with phase badge,
@@ -57,8 +19,8 @@ function getQualityColor(score: number): string {
  */
 export function LaunchCardMini({ launch }: LaunchCardMiniProps) {
   const navigate = useNavigate();
-  const phaseBadge = getPhaseBadge(launch.phase);
-  const categoryColor = getCategoryColor(launch.category);
+  const phaseBadge = PHASE_COLORS[launch.phase];
+  const categoryColor = CATEGORY_COLORS[launch.category];
   const qualityColor = getQualityColor(launch.qualityScore);
 
   const handleView = (e: React.MouseEvent) => {
@@ -67,7 +29,7 @@ export function LaunchCardMini({ launch }: LaunchCardMiniProps) {
   };
 
   return (
-    <div className="bg-slate-900 border border-[#1A1A1A] rounded-lg p-4 hover:border-[#333] transition">
+    <div className="bg-slate-900 border border-terminal-border rounded-lg p-4 hover:border-terminal-border-light transition">
       {/* Header Row */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1 min-w-0">
@@ -118,7 +80,7 @@ export function LaunchCardMini({ launch }: LaunchCardMiniProps) {
             {launch.qualityScore}
           </span>
         </div>
-        <div className="w-full h-1.5 bg-[#1A1A1A] rounded-full overflow-hidden">
+        <div className="w-full h-1.5 bg-slate-800 rounded-full overflow-hidden">
           <div
             className="h-full transition-all"
             style={{

--- a/frontend/src/components/home/LaunchpadRail.tsx
+++ b/frontend/src/components/home/LaunchpadRail.tsx
@@ -64,7 +64,7 @@ export function LaunchpadRail({ hideCreateCard = false }: LaunchpadRailProps) {
       {/* Trending Launches */}
       <section>
         <div className="flex items-center gap-2 mb-4">
-          <Sparkles className="w-4 h-4 text-[#22D3EE]" />
+          <Sparkles className="w-4 h-4 text-echelon-cyan" />
           <h2 className="text-sm font-semibold text-terminal-text uppercase tracking-wide">
             Trending Launches
           </h2>
@@ -91,7 +91,7 @@ export function LaunchpadRail({ hideCreateCard = false }: LaunchpadRailProps) {
           </h2>
         </div>
         {feed.drafts.length === 0 ? (
-          <div className="bg-slate-900 border border-[#1A1A1A] rounded-lg p-8 text-center">
+          <div className="bg-slate-900 border border-terminal-border rounded-lg p-8 text-center">
             <FileText className="w-12 h-12 text-terminal-text-muted mx-auto mb-3 opacity-50" />
             <p className="text-sm text-terminal-text-muted mb-2">No drafts yet</p>
             <p className="text-xs text-terminal-text-muted">
@@ -110,7 +110,7 @@ export function LaunchpadRail({ hideCreateCard = false }: LaunchpadRailProps) {
       {/* Recently Graduated */}
       <section>
         <div className="flex items-center gap-2 mb-4">
-          <div className="w-4 h-4 rounded-full bg-[#00FF41] opacity-50" />
+          <div className="w-4 h-4 rounded-full bg-status-success opacity-50" />
           <h2 className="text-sm font-semibold text-terminal-text uppercase tracking-wide">
             Recently Graduated
           </h2>

--- a/frontend/src/components/marketplace/AlertPanel.tsx
+++ b/frontend/src/components/marketplace/AlertPanel.tsx
@@ -196,14 +196,14 @@ export function AlertPanel({ isOpen, onClose }: AlertPanelProps) {
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 z-[9998]"
+        className="fixed inset-0 z-[200] bg-black/40"
         onClick={onClose}
       />
 
       {/* Panel */}
       <div
         ref={panelRef}
-        className="fixed top-16 right-4 w-96 max-h-[calc(100vh-8rem)] bg-terminal-panel border border-terminal-border rounded-xl shadow-2xl z-[9999] flex flex-col overflow-hidden"
+        className="fixed top-16 right-4 w-96 max-h-[calc(100vh-8rem)] bg-terminal-overlay border border-terminal-border rounded-xl shadow-2xl z-[210] flex flex-col overflow-hidden"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-terminal-border bg-terminal-bg/50">

--- a/frontend/src/components/marketplace/CompareSidebar.tsx
+++ b/frontend/src/components/marketplace/CompareSidebar.tsx
@@ -120,14 +120,14 @@ export function CompareSidebar({ isOpen, onClose }: CompareSidebarProps) {
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/50 z-[9998]"
+        className="fixed inset-0 bg-black/50 z-[200]"
         onClick={onClose}
       />
 
       {/* Sidebar */}
       <div
         ref={sidebarRef}
-        className="fixed top-0 right-0 h-full w-[480px] max-w-[90vw] bg-terminal-panel border-l border-terminal-border shadow-2xl z-[9999] flex flex-col transition-transform duration-300"
+        className="fixed top-0 right-0 h-full w-[480px] max-w-[90vw] bg-terminal-overlay border-l border-terminal-border shadow-2xl z-[210] flex flex-col transition-transform duration-300"
         style={{ transform: isOpen ? 'translateX(0)' : 'translateX(100%)' }}
       >
         {/* Header */}

--- a/frontend/src/components/paradox/BreachesModal.tsx
+++ b/frontend/src/components/paradox/BreachesModal.tsx
@@ -31,12 +31,12 @@ export function BreachesModal({ paradoxes, onClose }: BreachesModalProps) {
 
   return (
     <div 
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
       style={{ pointerEvents: 'auto' }}
     >
       <div 
-        className="w-full max-w-4xl max-h-[90vh] bg-terminal-panel border border-terminal-border rounded-lg shadow-2xl flex flex-col overflow-hidden"
+        className="w-full max-w-4xl max-h-[90vh] bg-terminal-overlay border border-terminal-border rounded-lg shadow-2xl flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/frontend/src/components/paradox/ParadoxAlert.tsx
+++ b/frontend/src/components/paradox/ParadoxAlert.tsx
@@ -186,14 +186,14 @@ export function ParadoxAlert({ paradox }: ParadoxAlertProps) {
         <>
           {/* Dark overlay - blocks all background content and pointer events */}
           <div 
-            className="fixed inset-0 bg-black/95 backdrop-blur-md z-[9990]"
+            className="fixed inset-0 bg-black/95 backdrop-blur-md z-[400]"
             style={{ pointerEvents: 'auto' }}
             onClick={() => setShowExtractionModal(false)}
           />
           
           {/* Modal content - above overlay */}
           <div 
-            className="fixed inset-0 z-[9995] flex items-center justify-center p-4 pointer-events-none"
+            className="fixed inset-0 z-[410] flex items-center justify-center p-4 pointer-events-none"
             onClick={(e) => {
               // Close on backdrop click
               if (e.target === e.currentTarget) setShowExtractionModal(false);
@@ -288,14 +288,14 @@ export function ParadoxAlert({ paradox }: ParadoxAlertProps) {
         <>
           {/* Dark overlay - blocks all background content and pointer events */}
           <div 
-            className="fixed inset-0 bg-black/95 backdrop-blur-md z-[9990]"
+            className="fixed inset-0 bg-black/95 backdrop-blur-md z-[400]"
             style={{ pointerEvents: 'auto' }}
             onClick={() => setShowAbandonModal(false)}
           />
           
           {/* Modal content - above overlay */}
           <div 
-            className="fixed inset-0 z-[9995] flex items-center justify-center p-4 pointer-events-none"
+            className="fixed inset-0 z-[410] flex items-center justify-center p-4 pointer-events-none"
             onClick={(e) => {
               // Close on backdrop click
               if (e.target === e.currentTarget) setShowAbandonModal(false);

--- a/frontend/src/components/replay/ReplayDrawer.tsx
+++ b/frontend/src/components/replay/ReplayDrawer.tsx
@@ -197,16 +197,16 @@ export function ReplayDrawer({ open, onClose, pointer }: ReplayDrawerProps) {
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/80 z-40 md:bg-black/60"
+        className="fixed inset-0 bg-black/80 z-[200] md:bg-black/60"
         onClick={onClose}
       />
 
       {/* Drawer */}
       <div
         className={`
-          fixed top-0 right-0 bottom-0 z-50
+          fixed top-0 right-0 bottom-0 z-[210]
           w-full md:w-[420px]
-          bg-terminal-panel border-l border-terminal-border
+          bg-terminal-overlay border-l border-terminal-border
           flex flex-col
           shadow-xl
           transform transition-transform duration-300 ease-out

--- a/frontend/src/components/watchlist/SavedViewEditorModal.tsx
+++ b/frontend/src/components/watchlist/SavedViewEditorModal.tsx
@@ -78,7 +78,7 @@ export function SavedViewEditorModal({
 
   return (
     <div
-      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 bg-black/80 flex items-center justify-center z-[300] p-4"
       onClick={onClose}
     >
       <div

--- a/frontend/src/constants/launchpad.ts
+++ b/frontend/src/constants/launchpad.ts
@@ -1,0 +1,23 @@
+import type { LaunchPhase, LaunchCategory } from '../types/launchpad';
+
+/** Phase badge colours — single source of truth across all Launchpad components */
+export const PHASE_COLORS: Record<LaunchPhase, { bg: string; text: string; label: string }> = {
+  draft:     { bg: '#64748B', text: '#FFFFFF', label: 'DRAFT' },
+  sandbox:   { bg: '#F59E0B', text: '#FFFFFF', label: 'SANDBOX' },
+  pilot:     { bg: '#22D3EE', text: '#000000', label: 'PILOT' },
+  graduated: { bg: '#10B981', text: '#FFFFFF', label: 'GRADUATED' },
+  failed:    { bg: '#EF4444', text: '#FFFFFF', label: 'FAILED' },
+};
+
+/** Category badge colours — single source of truth */
+export const CATEGORY_COLORS: Record<LaunchCategory, string> = {
+  theatre: '#22D3EE', // echelon-cyan
+  osint:   '#8B5CF6', // status-paradox
+};
+
+/** Quality score colour thresholds */
+export function getQualityColor(score: number): string {
+  if (score >= 80) return '#10B981'; // emerald
+  if (score >= 60) return '#F59E0B'; // amber
+  return '#EF4444'; // red
+}

--- a/frontend/src/demo/DemoBetModal.tsx
+++ b/frontend/src/demo/DemoBetModal.tsx
@@ -26,10 +26,10 @@ export function DemoBetModal(props: {
   return (
     <>
       <div
-        className="fixed inset-0 bg-black/95 backdrop-blur-md z-[9990]"
+        className="fixed inset-0 bg-black/95 backdrop-blur-md z-[300]"
         onClick={props.onClose}
       />
-      <div className="fixed inset-0 z-[9995] flex items-center justify-center">
+      <div className="fixed inset-0 z-[310] flex items-center justify-center">
         <div className="w-[440px] bg-[#0D0D0D] border border-purple-500/40 rounded-lg p-4 shadow-2xl">
           <div className="mb-3">
             <div className="text-xs text-slate-400">Place bet</div>

--- a/frontend/src/demo/DemoToastHost.tsx
+++ b/frontend/src/demo/DemoToastHost.tsx
@@ -12,7 +12,7 @@ export function DemoToastHost() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed right-4 top-4 z-[100] flex w-[320px] flex-col gap-2">
+    <div className="fixed right-4 top-4 z-[500] flex w-[320px] flex-col gap-2">
       {toasts.map((t) => (
         <div
           key={t.id}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,11 @@
     @apply border-glass-border-light bg-glass-card;
   }
 
+  /* Solid overlay surface for modals/drawers/sidebars */
+  .overlay-surface {
+    @apply bg-terminal-overlay border border-glass-border shadow-2xl;
+  }
+
   /* Status pill styles */
   .status-pill {
     @apply inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium;
@@ -225,7 +230,7 @@
 
   /* Ensure header dropdowns can overflow */
   .header-dropdown {
-    z-index: 9999;
+    z-index: 100;
     position: fixed;
   }
 
@@ -235,13 +240,13 @@
     inset: 0;
     background: rgba(11, 12, 14, 0.9);
     backdrop-filter: blur(8px);
-    z-index: 9990;
+    z-index: 300;
     pointer-events: auto;
   }
 
   .modal-content {
     position: fixed;
-    z-index: 9995;
+    z-index: 310;
     pointer-events: auto;
   }
 

--- a/frontend/src/pages/BlackboxPage.tsx
+++ b/frontend/src/pages/BlackboxPage.tsx
@@ -164,8 +164,7 @@ export function BlackboxPage() {
       {/* Alert Panel Backdrop */}
       {alertPanelOpen && (
         <div
-          className="fixed inset-0 z-40"
-          style={{ background: 'rgba(0,0,0,0.3)' }}
+          className="fixed inset-0 z-[200] bg-black/40"
           onClick={() => setAlertPanelOpen(false)}
         />
       )}
@@ -174,7 +173,7 @@ export function BlackboxPage() {
       {alertPanelOpen && (
         <div
           ref={alertPanelRef}
-          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl bg-terminal-panel border border-terminal-border"
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
@@ -195,8 +194,7 @@ export function BlackboxPage() {
       {/* Compare Panel Backdrop */}
       {comparePanelOpen && (
         <div
-          className="fixed inset-0 z-40"
-          style={{ background: 'rgba(0,0,0,0.3)' }}
+          className="fixed inset-0 z-[200] bg-black/40"
           onClick={() => setComparePanelOpen(false)}
         />
       )}
@@ -205,7 +203,7 @@ export function BlackboxPage() {
       {comparePanelOpen && (
         <div
           ref={comparePanelRef}
-          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl bg-terminal-panel border border-terminal-border"
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
@@ -226,8 +224,7 @@ export function BlackboxPage() {
       {/* Settings Panel Backdrop */}
       {settingsPanelOpen && (
         <div
-          className="fixed inset-0 z-40"
-          style={{ background: 'rgba(0,0,0,0.3)' }}
+          className="fixed inset-0 z-[200] bg-black/40"
           onClick={() => setSettingsPanelOpen(false)}
         />
       )}
@@ -236,7 +233,7 @@ export function BlackboxPage() {
       {settingsPanelOpen && (
         <div
           ref={settingsPanelRef}
-          className="fixed top-[60px] right-6 w-80 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl bg-terminal-panel border border-terminal-border"
+          className="fixed top-[60px] right-6 w-80 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">

--- a/frontend/src/pages/LaunchpadDetailPage.tsx
+++ b/frontend/src/pages/LaunchpadDetailPage.tsx
@@ -5,45 +5,7 @@ import { listLaunches } from '../api/launchpad';
 import { ReplayDrawer } from '../components/replay/ReplayDrawer';
 import type { LaunchCard } from '../types/launchpad';
 import type { ReplayPointer } from '../types/replay';
-
-/**
- * Get phase badge color and label
- */
-function getPhaseBadge(phase: LaunchCard['phase']): { bg: string; text: string; label: string } {
-  switch (phase) {
-    case 'draft':
-      return { bg: '#666666', text: '#FFFFFF', label: 'DRAFT' };
-    case 'sandbox':
-      return { bg: '#FF9500', text: '#FFFFFF', label: 'SANDBOX' };
-    case 'pilot':
-      return { bg: '#22D3EE', text: '#000000', label: 'PILOT' };
-    case 'graduated':
-      return { bg: '#00FF41', text: '#000000', label: 'GRADUATED' };
-    case 'failed':
-      return { bg: '#FF3B3B', text: '#FFFFFF', label: 'FAILED' };
-  }
-}
-
-/**
- * Get category badge color
- */
-function getCategoryColor(category: LaunchCard['category']): string {
-  switch (category) {
-    case 'theatre':
-      return '#22D3EE';
-    case 'osint':
-      return '#9932CC';
-  }
-}
-
-/**
- * Get quality score color
- */
-function getQualityColor(score: number): string {
-  if (score >= 80) return '#00FF41'; // green
-  if (score >= 60) return '#FF9500'; // amber
-  return '#FF3B3B'; // red
-}
+import { PHASE_COLORS, CATEGORY_COLORS, getQualityColor } from '../constants/launchpad';
 
 /**
  * Mock mapping of launch IDs to timeline IDs
@@ -170,8 +132,8 @@ export function LaunchpadDetailPage() {
     );
   }
 
-  const phaseBadge = getPhaseBadge(launch.phase);
-  const categoryColor = getCategoryColor(launch.category);
+  const phaseBadge = PHASE_COLORS[launch.phase];
+  const categoryColor = CATEGORY_COLORS[launch.category];
   const qualityColor = getQualityColor(launch.qualityScore);
   const canOpenMarket = launch.phase === 'graduated' && launchToTimelineMap[launch.id];
 
@@ -201,7 +163,7 @@ export function LaunchpadDetailPage() {
               {launch.category.toUpperCase()}
             </span>
             {launch.exportEligible && (
-              <span className="flex items-center gap-1 text-xs text-[#22D3EE]">
+              <span className="flex items-center gap-1 text-xs text-echelon-cyan">
                 <Database className="w-3 h-3" />
                 EXPORT ELIGIBLE
               </span>
@@ -229,7 +191,7 @@ export function LaunchpadDetailPage() {
             </span>
             <span className="text-sm text-terminal-text-muted">/ 100</span>
           </div>
-          <div className="w-full h-2 bg-[#1A1A1A] rounded-full overflow-hidden">
+          <div className="w-full h-2 bg-slate-800 rounded-full overflow-hidden">
             <div
               className="h-full transition-all"
               style={{
@@ -313,7 +275,7 @@ export function LaunchpadDetailPage() {
           disabled={!canOpenMarket}
           className={`flex items-center gap-2 px-6 py-3 text-sm font-semibold rounded transition ${
             canOpenMarket
-              ? 'bg-[#22D3EE]/20 border border-[#22D3EE] text-[#22D3EE] hover:bg-[#22D3EE]/30'
+              ? 'bg-echelon-cyan/20 border border-echelon-cyan text-echelon-cyan hover:bg-echelon-cyan/30'
               : 'bg-terminal-bg border border-terminal-border text-terminal-text-muted cursor-not-allowed'
           }`}
         >
@@ -322,7 +284,7 @@ export function LaunchpadDetailPage() {
         </button>
         <button
           onClick={handleViewReplay}
-          className="flex items-center gap-2 px-6 py-3 text-sm font-semibold bg-terminal-bg border border-terminal-border rounded hover:border-[#22D3EE] hover:text-[#22D3EE] transition"
+          className="flex items-center gap-2 px-6 py-3 text-sm font-semibold bg-terminal-bg border border-terminal-border rounded hover:border-echelon-cyan hover:text-echelon-cyan transition"
         >
           <Play className="w-4 h-4" />
           VIEW REPLAY

--- a/frontend/src/pages/LaunchpadNewPage.tsx
+++ b/frontend/src/pages/LaunchpadNewPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight, ArrowLeft, Check, Sparkles } from 'lucide-react';
 import { setHomePreference } from '../lib/userPrefs';
+import { demoStore } from '../demo/demoStore';
 import type { LaunchCategory } from '../types/launchpad';
 
 type WizardStep = 1 | 2 | 3;
@@ -79,6 +80,9 @@ export function LaunchpadNewPage() {
       // Set home preference to launchpad when user completes wizard
       setHomePreference('launchpad');
 
+      // Show success toast
+      demoStore.pushToast('Timeline Draft Created', `"${title.trim()}" saved to your drafts`);
+
       // Redirect to launchpad
       navigate('/launchpad');
     } catch (error) {
@@ -110,9 +114,9 @@ export function LaunchpadNewPage() {
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold transition ${
                 s < step
-                  ? 'bg-[#22D3EE] text-black'
+                  ? 'bg-echelon-cyan text-black'
                   : s === step
-                  ? 'bg-[#22D3EE]/20 border-2 border-[#22D3EE] text-[#22D3EE]'
+                  ? 'bg-echelon-cyan/20 border-2 border-echelon-cyan text-echelon-cyan'
                   : 'bg-terminal-bg border border-terminal-border text-terminal-text-muted'
               }`}
             >
@@ -121,7 +125,7 @@ export function LaunchpadNewPage() {
             {s < 3 && (
               <div
                 className={`h-0.5 flex-1 transition ${
-                  s < step ? 'bg-[#22D3EE]' : 'bg-terminal-border'
+                  s < step ? 'bg-echelon-cyan' : 'bg-terminal-border'
                 }`}
               />
             )}
@@ -142,16 +146,13 @@ export function LaunchpadNewPage() {
                 onClick={() => setCategory('theatre')}
                 className={`p-6 bg-slate-900 border-2 rounded-lg transition text-left ${
                   category === 'theatre'
-                    ? 'border-[#22D3EE] bg-[#22D3EE]/10'
-                    : 'border-terminal-border hover:border-[#333]'
+                    ? 'border-echelon-cyan bg-echelon-cyan/10'
+                    : 'border-terminal-border hover:border-terminal-border-light'
                 }`}
               >
                 <div className="flex items-center gap-3 mb-2">
-                  <div
-                    className="w-12 h-12 rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: `${'#22D3EE'}20` }}
-                  >
-                    <Sparkles className="w-6 h-6" style={{ color: '#22D3EE' }} />
+                  <div className="w-12 h-12 rounded-full flex items-center justify-center bg-echelon-cyan/[0.12]">
+                    <Sparkles className="w-6 h-6 text-echelon-cyan" />
                   </div>
                   <h3 className="text-lg font-bold text-terminal-text">THEATRE</h3>
                 </div>
@@ -164,16 +165,13 @@ export function LaunchpadNewPage() {
                 onClick={() => setCategory('osint')}
                 className={`p-6 bg-slate-900 border-2 rounded-lg transition text-left ${
                   category === 'osint'
-                    ? 'border-[#9932CC] bg-[#9932CC]/10'
-                    : 'border-terminal-border hover:border-[#333]'
+                    ? 'border-status-paradox bg-status-paradox/10'
+                    : 'border-terminal-border hover:border-terminal-border-light'
                 }`}
               >
                 <div className="flex items-center gap-3 mb-2">
-                  <div
-                    className="w-12 h-12 rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: `${'#9932CC'}20` }}
-                  >
-                    <Sparkles className="w-6 h-6" style={{ color: '#9932CC' }} />
+                  <div className="w-12 h-12 rounded-full flex items-center justify-center bg-status-paradox/[0.12]">
+                    <Sparkles className="w-6 h-6 text-status-paradox" />
                   </div>
                   <h3 className="text-lg font-bold text-terminal-text">OSINT</h3>
                 </div>
@@ -201,7 +199,7 @@ export function LaunchpadNewPage() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="Enter timeline title..."
-                className="w-full px-4 py-3 bg-terminal-bg border border-terminal-border rounded focus:border-[#22D3EE] focus:outline-none text-terminal-text"
+                className="w-full px-4 py-3 bg-terminal-bg border border-terminal-border rounded focus:border-echelon-cyan focus:outline-none text-terminal-text"
                 autoFocus
               />
             </div>
@@ -215,7 +213,7 @@ export function LaunchpadNewPage() {
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
                 placeholder="e.g., geopolitics, shipping, middle-east"
-                className="w-full px-4 py-3 bg-terminal-bg border border-terminal-border rounded focus:border-[#22D3EE] focus:outline-none text-terminal-text"
+                className="w-full px-4 py-3 bg-terminal-bg border border-terminal-border rounded focus:border-echelon-cyan focus:outline-none text-terminal-text"
               />
               <p className="text-xs text-terminal-text-muted mt-2">
                 Separate multiple tags with commas
@@ -274,7 +272,7 @@ export function LaunchpadNewPage() {
           className={`flex items-center gap-2 px-4 py-2 text-sm font-semibold rounded transition ${
             step === 1
               ? 'bg-terminal-bg border border-terminal-border text-terminal-text-muted cursor-not-allowed'
-              : 'bg-terminal-bg border border-terminal-border text-terminal-text hover:border-[#22D3EE] hover:text-[#22D3EE]'
+              : 'bg-terminal-bg border border-terminal-border text-terminal-text hover:border-echelon-cyan hover:text-echelon-cyan'
           }`}
         >
           <ArrowLeft className="w-4 h-4" />
@@ -290,7 +288,7 @@ export function LaunchpadNewPage() {
             className={`flex items-center gap-2 px-6 py-2 text-sm font-semibold rounded transition ${
               (step === 1 && !canProceedStep1) || (step === 2 && !canProceedStep2)
                 ? 'bg-terminal-bg border border-terminal-border text-terminal-text-muted cursor-not-allowed'
-                : 'bg-[#22D3EE]/20 border border-[#22D3EE] text-[#22D3EE] hover:bg-[#22D3EE]/30'
+                : 'bg-echelon-cyan/20 border border-echelon-cyan text-echelon-cyan hover:bg-echelon-cyan/30'
             }`}
           >
             Next
@@ -303,7 +301,7 @@ export function LaunchpadNewPage() {
             className={`flex items-center gap-2 px-6 py-2 text-sm font-semibold rounded transition ${
               !canSubmit || isSubmitting
                 ? 'bg-terminal-bg border border-terminal-border text-terminal-text-muted cursor-not-allowed'
-                : 'bg-[#22D3EE]/20 border border-[#22D3EE] text-[#22D3EE] hover:bg-[#22D3EE]/30'
+                : 'bg-echelon-cyan/20 border border-echelon-cyan text-echelon-cyan hover:bg-echelon-cyan/30'
             }`}
           >
             {isSubmitting ? 'Creating...' : 'CREATE DRAFT'}

--- a/frontend/src/pages/MarketplacePage.tsx
+++ b/frontend/src/pages/MarketplacePage.tsx
@@ -453,8 +453,7 @@ export function MarketplacePage() {
       {/* Alert Notification Panel Backdrop */}
       {alertsPanelOpen && (
         <div
-          className="fixed inset-0 z-40"
-          style={{ background: 'rgba(0,0,0,0.3)' }}
+          className="fixed inset-0 z-[200] bg-black/40"
           onClick={() => setAlertsPanelOpen(false)}
         />
       )}
@@ -463,7 +462,7 @@ export function MarketplacePage() {
       {alertsPanelOpen && (
         <div
           ref={alertPanelRef}
-          className="fixed top-[60px] right-6 w-[380px] max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-50 shadow-xl bg-terminal-panel border border-terminal-border"
+          className="fixed top-[60px] right-6 w-[380px] max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
@@ -598,12 +597,12 @@ export function MarketplacePage() {
       {/* Alert Management Modal */}
       {alertsModalOpen && (
         <div 
-          className="fixed inset-0 z-50 flex items-center justify-center"
+          className="fixed inset-0 z-[300] flex items-center justify-center"
           style={{ background: 'rgba(0,0,0,0.7)', backdropFilter: 'blur(4px)' }}
           onClick={() => setAlertsModalOpen(false)}
         >
           <div
-            className="rounded-xl w-[600px] max-w-[90vw] max-h-[85vh] flex flex-col shadow-xl bg-terminal-panel border border-terminal-border"
+            className="rounded-xl w-[600px] max-w-[90vw] max-h-[85vh] flex flex-col shadow-xl bg-terminal-overlay border border-terminal-border"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between px-5 py-4 border-b bg-terminal-card border-terminal-border">
@@ -757,14 +756,14 @@ export function MarketplacePage() {
 
       {/* Compare Sidebar Backdrop */}
       <div
-        className={`fixed inset-0 z-40 transition-opacity duration-300 ${compareSidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-        style={{ background: 'rgba(0,0,0,0.3)' }}
+        className={`fixed inset-0 z-[200] transition-opacity duration-300 ${compareSidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        style={{ background: 'rgba(0,0,0,0.4)' }}
         onClick={() => setCompareSidebarOpen(false)}
       />
 
       {/* Compare Sidebar */}
       <div
-        className={`fixed top-0 h-full shadow-xl z-[1500] flex flex-col transition-all duration-300 ease-out bg-terminal-panel border-l border-terminal-border ${compareSidebarOpen ? 'right-0' : 'right-[-480px]'}`}
+        className={`fixed top-0 h-full shadow-xl z-[210] flex flex-col transition-all duration-300 ease-out bg-terminal-overlay border-l border-terminal-border ${compareSidebarOpen ? 'right-0' : 'right-[-480px]'}`}
         style={{ width: '480px' }}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b bg-terminal-card border-terminal-border">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -48,6 +48,7 @@ export default {
           'bg': '#030305',      // Deep Charcoal
           'panel': 'rgba(255, 255, 255, 0.03)',
           'card': 'rgba(255, 255, 255, 0.03)',
+          'overlay': '#121417', // Solid surface for overlays/modals/drawers
           'border': 'rgba(255, 255, 255, 0.1)',
           'border-light': 'rgba(255, 255, 255, 0.2)',
           'text': '#F3F4F6',    // Primary text


### PR DESCRIPTION
…colors

- Add terminal.overlay (#121417) token for solid modal/drawer surfaces
- Replace bg-terminal-panel with bg-terminal-overlay on all 9 overlay components (BreachesModal, ReplayDrawer, CompareSidebar, GhostForks, AlertPanel, MarketplacePage x3, BlackboxPage x3)
- Fix AlertPanel backdrop: was fully transparent, now bg-black/40
- Standardize z-index hierarchy: tooltips z-100, drawers z-200/210, modals z-300/310, critical alerts z-400/410, toasts z-500
- Extract shared PHASE_COLORS, CATEGORY_COLORS, getQualityColor into constants/launchpad.ts — single source of truth
- Replace 11x hardcoded #22D3EE and 3x #9932CC in LaunchpadNewPage with echelon-cyan / status-paradox tokens
- Unify phase badge colors across LaunchpadDetailPage, LaunchCardMini, and LaunchpadRail (were using conflicting palettes)
- Add launch success toast via demoStore.pushToast on draft creation
- Update CSS z-index: .modal-backdrop 9990→300, .modal-content 9995→310