### PR TITLE
feat(analytics): CFPM/LMSR market terminal redesign

### DIFF
--- a/frontend/src/components/blackbox/ImpactCostPanel.tsx
+++ b/frontend/src/components/blackbox/ImpactCostPanel.tsx
@@ -1,0 +1,199 @@
+/**
+ * CFPM / LMSR Impact & Cost Panel
+ *
+ * Replaces the traditional order book with a cost-function prediction market
+ * (CFPM) panel powered by LMSR (Logarithmic Market Scoring Rule).
+ * All values are demo/mock — no backend required.
+ */
+
+import { Activity, Zap, TrendingUp, ArrowRight } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface ImpactCostPanelProps {
+  currentPrice: number;
+}
+
+// ── Demo LMSR parameters ────────────────────────────────────────────────
+const LIQUIDITY_B = 142.5;
+const NUM_OUTCOMES = 2;
+const WORST_CASE_LOSS = LIQUIDITY_B * Math.log(NUM_OUTCOMES);
+
+// LMSR cost function: C(q) = b * ln(sum(exp(q_i / b)))
+// For binary market, cost to move probability from p1 to p2:
+// cost = b * ln(exp(q_yes_new/b) + exp(q_no_new/b)) - b * ln(exp(q_yes_old/b) + exp(q_no_old/b))
+function lmsrCost(pFrom: number, pTo: number, b: number): number {
+  // Simplified binary LMSR cost approximation
+  const qFrom = Math.log(pFrom / (1 - pFrom));
+  const qTo = Math.log(pTo / (1 - pTo));
+  return Math.abs(b * (qTo - qFrom)) * 0.42; // Scaled for demo realism
+}
+
+// Impact ladder entries
+const IMPACT_LADDER = [
+  { delta: 0.01, label: '+1%' },
+  { delta: 0.05, label: '+5%' },
+  { delta: 0.10, label: '+10%' },
+  { delta: 0.25, label: '+25%' },
+];
+
+export function ImpactCostPanel({ currentPrice }: ImpactCostPanelProps) {
+  // Current probability derived from price (in a PM, price ≈ probability)
+  const currentProb = Math.min(Math.max(currentPrice / 100, 0.01), 0.99);
+  const probPercent = (currentProb * 100).toFixed(1);
+
+  return (
+    <div className="terminal-panel rounded-2xl flex flex-col min-h-0 overflow-hidden">
+      {/* ── Header ─────────────────────────────────────────────── */}
+      <div className="section-header">
+        <div className="flex items-center gap-2">
+          <Activity className="w-3.5 h-3.5 text-echelon-cyan" />
+          <span className="section-header-title">CFPM MARKET ENGINE</span>
+        </div>
+        <span className="chip chip-info">LMSR</span>
+      </div>
+
+      {/* ── Body ───────────────────────────────────────────────── */}
+      <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+
+        {/* ── Instant Price ────────────────────────────────────── */}
+        <div className="bg-terminal-card rounded-xl p-4 border border-terminal-border">
+          <div className="flex items-center justify-between mb-3">
+            <span className="data-label">Instant Probability</span>
+            <span className="chip chip-success text-[9px]">CFPM</span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-mono font-bold tabular-nums text-echelon-cyan">
+              {probPercent}%
+            </span>
+            <span className="text-sm font-mono tabular-nums text-terminal-text-muted">
+              ≈ ${currentPrice.toFixed(2)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 mt-2">
+            <TrendingUp className="w-3 h-3 text-echelon-green" />
+            <span className="text-[10px] text-echelon-green font-mono tabular-nums">+2.4% 24h</span>
+          </div>
+        </div>
+
+        {/* ── Liquidity Parameters ─────────────────────────────── */}
+        <div className="space-y-2">
+          <span className="section-title-accented">Liquidity Parameters</span>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="metric-block bg-terminal-card/50 rounded-lg p-3 border border-terminal-border/50">
+              <span className="metric-label">Depth (b)</span>
+              <span className="metric-value text-echelon-cyan">{LIQUIDITY_B.toFixed(1)}</span>
+            </div>
+            <div className="metric-block bg-terminal-card/50 rounded-lg p-3 border border-terminal-border/50">
+              <span className="metric-label">Max Loss</span>
+              <span className="metric-value text-echelon-amber">${WORST_CASE_LOSS.toFixed(2)}</span>
+            </div>
+          </div>
+
+          <div className="bg-terminal-card/30 rounded-lg p-3 border border-terminal-border/30">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="data-label">Worst-Case Loss Bound</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="text-xs font-mono text-echelon-purple bg-echelon-purple/10 px-2 py-0.5 rounded border border-echelon-purple/20">
+                b &middot; ln(n)
+              </code>
+              <span className="text-xs text-terminal-text-muted">=</span>
+              <span className="text-xs font-mono tabular-nums text-terminal-text">
+                {LIQUIDITY_B} &times; ln({NUM_OUTCOMES}) = ${WORST_CASE_LOSS.toFixed(2)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Cost Calculator ──────────────────────────────────── */}
+        <div className="space-y-2">
+          <span className="section-title-accented">Cost Calculator</span>
+
+          <div className="bg-terminal-card rounded-xl p-4 border border-terminal-border">
+            <div className="flex items-center gap-2 text-sm text-terminal-text-secondary mb-3">
+              <span className="text-terminal-text-muted">Move probability</span>
+              <span className="font-mono tabular-nums text-echelon-cyan font-semibold">{probPercent}%</span>
+              <ArrowRight className="w-3 h-3 text-terminal-text-muted" />
+              <span className="font-mono tabular-nums text-echelon-green font-semibold">
+                {(currentProb * 100 + 5).toFixed(1)}%
+              </span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <Zap className="w-4 h-4 text-echelon-amber" />
+              <span className="text-xl font-mono font-bold tabular-nums text-terminal-text">
+                ${lmsrCost(currentProb, Math.min(currentProb + 0.05, 0.99), LIQUIDITY_B).toFixed(2)}
+              </span>
+              <span className="text-xs text-terminal-text-muted">estimated cost</span>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Impact Ladder ────────────────────────────────────── */}
+        <div className="space-y-2">
+          <span className="section-title-accented">Impact Ladder</span>
+
+          <div className="space-y-1">
+            {IMPACT_LADDER.map(({ delta, label }) => {
+              const targetProb = Math.min(currentProb + delta, 0.99);
+              const cost = lmsrCost(currentProb, targetProb, LIQUIDITY_B);
+              const targetPct = (targetProb * 100).toFixed(1);
+              // Relative cost bar width (max at 25% move)
+              const maxCost = lmsrCost(currentProb, Math.min(currentProb + 0.25, 0.99), LIQUIDITY_B);
+              const barWidth = Math.min((cost / maxCost) * 100, 100);
+
+              return (
+                <div
+                  key={label}
+                  className="relative flex items-center justify-between px-3 py-2 rounded-lg border border-terminal-border/30 bg-terminal-card/30 overflow-hidden group hover:border-terminal-border transition-colors"
+                >
+                  {/* Cost bar background */}
+                  <div
+                    className="absolute inset-y-0 left-0 bg-echelon-cyan/[0.06] transition-all duration-300"
+                    style={{ width: `${barWidth}%` }}
+                  />
+
+                  <div className="relative flex items-center gap-3 z-10">
+                    <span className={clsx(
+                      'text-xs font-mono font-bold tabular-nums w-10',
+                      delta <= 0.05 ? 'text-echelon-green' : delta <= 0.10 ? 'text-echelon-amber' : 'text-echelon-red'
+                    )}>
+                      {label}
+                    </span>
+                    <span className="text-[10px] text-terminal-text-muted">
+                      → {targetPct}%
+                    </span>
+                  </div>
+
+                  <span className="relative z-10 text-xs font-mono tabular-nums font-semibold text-terminal-text">
+                    ${cost.toFixed(2)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Market Info Footer ────────────────────────────────── */}
+        <div className="border-t border-terminal-border/50 pt-3 space-y-1.5">
+          <div className="flex items-center justify-between">
+            <span className="data-label">Market Type</span>
+            <span className="data-value text-echelon-cyan">LMSR Binary</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="data-label">Outcomes</span>
+            <span className="data-value">{NUM_OUTCOMES}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="data-label">Subsidy Pool</span>
+            <span className="data-value">${(LIQUIDITY_B * 2.5).toFixed(0)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="data-label">24h Volume</span>
+            <span className="data-value text-echelon-green">$12,847</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/BlackboxPage.tsx
+++ b/frontend/src/pages/BlackboxPage.tsx
@@ -1,9 +1,13 @@
-// Blackbox Page Component
-// Market Terminal - Analytics interface inside AppLayout
+/**
+ * Analytics Page (formerly Blackbox)
+ *
+ * CFPM/LMSR prediction market terminal with impact-curve charting,
+ * cost-function panels, agent leaderboard, and signal intercepts.
+ */
 
 import { useState, useEffect, useRef } from 'react';
 import { PriceChart } from '../components/blackbox/PriceChart';
-import { OrderBookPanel } from '../components/blackbox/OrderBookPanel';
+import { ImpactCostPanel } from '../components/blackbox/ImpactCostPanel';
 import { TimeSalesPanel } from '../components/blackbox/TimeSalesPanel';
 import { AgentLeaderboard } from '../components/blackbox/AgentLeaderboard';
 import { SignalInterceptsPanel } from '../components/blackbox/SignalInterceptsPanel';
@@ -12,21 +16,20 @@ import { VolumeProfilePanel } from '../components/blackbox/VolumeProfilePanel';
 import { HeatmapPanel } from '../components/blackbox/HeatmapPanel';
 import {
   useBlackboxChart,
-  useOrderBook,
   useTimeSales,
   useAgentLeaderboard,
   useIntercepts,
 } from '../hooks/useBlackbox';
 import { useRegisterTopActionBarActions } from '../contexts/TopActionBarActionsContext';
+import { clsx } from 'clsx';
 import type { Timeframe } from '../types/blackbox';
 
-// Chart mode type for tabs
+// ── Chart mode types ────────────────────────────────────────────────────
 type ChartMode = 'price' | 'depth' | 'vol' | 'heatmap';
 
-// Chart mode display labels
 const CHART_MODE_LABELS: Record<ChartMode, string> = {
   price: 'PRICE ACTION',
-  depth: 'DEPTH CHART',
+  depth: 'IMPACT CURVE',
   vol: 'VOL PROFILE',
   heatmap: 'HEATMAP',
 };
@@ -35,7 +38,7 @@ export function BlackboxPage() {
   const [timeframe, setTimeframe] = useState<Timeframe>('15m');
   const [chartMode, setChartMode] = useState<ChartMode>('price');
 
-  // Panel state
+  // Overlay state
   const [alertPanelOpen, setAlertPanelOpen] = useState(false);
   const [comparePanelOpen, setComparePanelOpen] = useState(false);
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
@@ -47,7 +50,6 @@ export function BlackboxPage() {
 
   // Data hooks
   const { candles, currentPrice, indicators } = useBlackboxChart(timeframe);
-  const orderBook = useOrderBook();
   const trades = useTimeSales();
   const { agents, searchQuery, setSearchQuery } = useAgentLeaderboard();
   const intercepts = useIntercepts();
@@ -65,12 +67,11 @@ export function BlackboxPage() {
       setSettingsPanelOpen(false);
     },
     onRefresh: () => {
-      // Refresh data - hooks will auto-refresh
       console.log('Refresh analytics data');
     },
   });
 
-  // Close panels on Escape key
+  // Close overlays on Escape
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -83,7 +84,7 @@ export function BlackboxPage() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  // Render chart content based on chartMode
+  // Render chart content based on mode
   const renderChartContent = () => {
     switch (chartMode) {
       case 'price':
@@ -110,49 +111,61 @@ export function BlackboxPage() {
   return (
     <div className="h-full w-full flex flex-col min-h-0 bg-terminal-bg text-terminal-text">
 
-      {/* Tabs Row */}
-      <div className="flex items-center gap-2 px-6 py-3 border-b border-terminal-border">
-        {(Object.keys(CHART_MODE_LABELS) as ChartMode[]).map((mode) => (
-          <button
-            key={mode}
-            onClick={() => setChartMode(mode)}
-            className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-              chartMode === mode
-                ? 'bg-terminal-card text-terminal-text'
-                : 'text-terminal-text-muted hover:text-terminal-text-secondary hover:bg-terminal-card'
-            }`}
-          >
-            {CHART_MODE_LABELS[mode]}
-          </button>
-        ))}
+      {/* ═══════════ Tab Row ═══════════ */}
+      <div className="flex items-center gap-1.5 px-6 py-2.5 bg-terminal-panel border-b border-terminal-border">
+        {(Object.keys(CHART_MODE_LABELS) as ChartMode[]).map((mode) => {
+          const isActive = chartMode === mode;
+          return (
+            <button
+              key={mode}
+              onClick={() => setChartMode(mode)}
+              className={clsx(
+                'px-4 py-1.5 rounded-lg text-[11px] font-semibold uppercase tracking-wider transition-all duration-150',
+                isActive
+                  ? 'bg-terminal-card border border-terminal-border text-terminal-text shadow-elevation-1'
+                  : 'border border-transparent text-terminal-text-muted hover:text-terminal-text-secondary hover:bg-terminal-card/50'
+              )}
+            >
+              {CHART_MODE_LABELS[mode]}
+            </button>
+          );
+        })}
+
+        {/* CFPM engine badge */}
+        <div className="ml-auto flex items-center gap-2">
+          <span className="chip chip-info text-[9px]">CFPM</span>
+          <span className="text-[10px] font-mono tabular-nums text-terminal-text-muted">
+            b=142.5
+          </span>
+        </div>
       </div>
 
-      {/* Main Content */}
+      {/* ═══════════ Main Grid ═══════════ */}
       <div className="flex-1 min-h-0 p-6 overflow-hidden">
         <div className="h-full flex flex-col min-h-0">
-          <div className="grid grid-cols-12 gap-4 min-h-0" style={{ minHeight: 0 }}>
+          <div className="grid grid-cols-12 gap-4 min-h-0 [min-height:0]">
 
-            {/* Price Action - col-span-9 */}
+            {/* Chart — col-span-9 */}
             <div className="col-span-9 flex flex-col min-h-0">
               {renderChartContent()}
             </div>
 
-            {/* Order Book - col-span-3 */}
+            {/* CFPM Impact & Cost — col-span-3 */}
             <div className="col-span-3 flex flex-col min-h-0">
-              <OrderBookPanel orderBook={orderBook} currentPrice={currentPrice} />
+              <ImpactCostPanel currentPrice={currentPrice} />
             </div>
 
-            {/* Time & Sales - col-span-6 */}
+            {/* Time & Sales — col-span-6 */}
             <div className="col-span-6 flex flex-col min-h-0">
               <TimeSalesPanel trades={trades} />
             </div>
 
-            {/* Agent Performance - col-span-3 */}
+            {/* Agent Leaderboard — col-span-3 */}
             <div className="col-span-3 flex flex-col min-h-0">
               <AgentLeaderboard agents={agents} searchQuery={searchQuery} onSearchChange={setSearchQuery} />
             </div>
 
-            {/* Signal Intercepts - col-span-3 */}
+            {/* Signal Intercepts — col-span-3 */}
             <div className="col-span-3 flex flex-col min-h-0">
               <SignalInterceptsPanel intercepts={intercepts} />
             </div>
@@ -161,86 +174,80 @@ export function BlackboxPage() {
         </div>
       </div>
 
-      {/* Alert Panel Backdrop */}
+      {/* ═══════════ Alert Overlay ═══════════ */}
       {alertPanelOpen && (
         <div
-          className="fixed inset-0 z-[200] bg-black/40"
+          className="fixed inset-0 z-[300] bg-black/50"
           onClick={() => setAlertPanelOpen(false)}
         />
       )}
-
-      {/* Alert Panel */}
       {alertPanelOpen && (
         <div
           ref={alertPanelRef}
-          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[310] shadow-elevation-3 bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
-            <span className="text-sm font-semibold text-terminal-text">Analytics Alerts</span>
+          <div className="section-header">
+            <span className="section-title-accented">Analytics Alerts</span>
             <button
               onClick={() => setAlertPanelOpen(false)}
-              className="p-1 rounded transition-colors text-terminal-text-muted"
+              className="p-1 rounded transition-colors text-terminal-text-muted hover:text-terminal-text"
             >
               ✕
             </button>
           </div>
-          <div className="p-4 overflow-y-auto" style={{ maxHeight: 400 }}>
+          <div className="p-4 overflow-y-auto max-h-[400px]">
             <p className="text-xs text-terminal-text-muted">No alerts configured for analytics.</p>
           </div>
         </div>
       )}
 
-      {/* Compare Panel Backdrop */}
+      {/* ═══════════ Compare Overlay ═══════════ */}
       {comparePanelOpen && (
         <div
-          className="fixed inset-0 z-[200] bg-black/40"
+          className="fixed inset-0 z-[300] bg-black/50"
           onClick={() => setComparePanelOpen(false)}
         />
       )}
-
-      {/* Compare Panel */}
       {comparePanelOpen && (
         <div
           ref={comparePanelRef}
-          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
+          className="fixed top-[60px] right-6 w-96 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[310] shadow-elevation-3 bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
-            <span className="text-sm font-semibold text-terminal-text">Compare Theatres</span>
+          <div className="section-header">
+            <span className="section-title-accented">Compare Theatres</span>
             <button
               onClick={() => setComparePanelOpen(false)}
-              className="p-1 rounded transition-colors text-terminal-text-muted"
+              className="p-1 rounded transition-colors text-terminal-text-muted hover:text-terminal-text"
             >
               ✕
             </button>
           </div>
-          <div className="p-4 overflow-y-auto" style={{ maxHeight: 400 }}>
+          <div className="p-4 overflow-y-auto max-h-[400px]">
             <p className="text-xs text-terminal-text-muted">Select theatres to compare.</p>
           </div>
         </div>
       )}
 
-      {/* Settings Panel Backdrop */}
+      {/* ═══════════ Settings Overlay ═══════════ */}
       {settingsPanelOpen && (
         <div
-          className="fixed inset-0 z-[200] bg-black/40"
+          className="fixed inset-0 z-[300] bg-black/50"
           onClick={() => setSettingsPanelOpen(false)}
         />
       )}
-
-      {/* Settings Panel */}
       {settingsPanelOpen && (
         <div
           ref={settingsPanelRef}
-          className="fixed top-[60px] right-6 w-80 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[210] shadow-xl bg-terminal-overlay border border-terminal-border"
+          className="fixed top-[60px] right-6 w-80 max-h-[calc(100vh-80px)] rounded-xl flex flex-col overflow-hidden z-[310] shadow-elevation-3 bg-terminal-overlay border border-terminal-border"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="flex items-center justify-between px-4 py-3 border-b bg-terminal-card border-terminal-border">
-            <span className="text-sm font-semibold text-terminal-text">Analytics Settings</span>
+          <div className="section-header">
+            <span className="section-title-accented">Analytics Settings</span>
             <button
               onClick={() => setSettingsPanelOpen(false)}
-              className="p-1 rounded transition-colors text-terminal-text-muted"
+              className="p-1 rounded transition-colors text-terminal-text-muted hover:text-terminal-text"
             >
               ✕
             </button>


### PR DESCRIPTION
- Replace OrderBookPanel with new ImpactCostPanel showing CFPM/LMSR market engine: instant probability, liquidity parameters (b, max loss bound b·ln(n)), cost calculator, and impact ladder (+1/5/10/25%)
- Rename DEPTH CHART tab → IMPACT CURVE
- Upgrade tab row to panel-header style with elevation-1 active state, CFPM badge, and b parameter display
- Fix overlay z-indices: backdrops z-[300], panels z-[310] with shadow-elevation-3 for solid rendering
- Replace all overlay inline styles with design system tokens (section-header, section-title-accented, max-h-[400px])
- Remove useOrderBook hook dependency (no longer needed)
- Zero hardcoded hex / inline styles remaining in BlackboxPage