### PR TITLE
feat(analytics): replace order-book depth chart with LMSR impact curve

### DIFF
--- a/frontend/src/components/blackbox/DepthChartPanel.tsx
+++ b/frontend/src/components/blackbox/DepthChartPanel.tsx
@@ -1,217 +1,353 @@
-import { useMemo, useRef, useEffect, useState } from 'react';
-import { useOrderBook } from '../../hooks/useBlackbox';
+/**
+ * LMSR Impact Curve Panel
+ *
+ * Renders a "Cost to Move" chart showing how much it costs to shift the
+ * market probability by a given delta.  X-axis = Target Probability (%),
+ * Y-axis = Cost ($).  Single smooth cyan curve, interactive hover tooltip,
+ * and a cost-to-move calculator strip below the chart.
+ *
+ * No order-book artifacts — this is pure CFPM/LMSR.
+ */
+
+import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import { CHART } from '../../constants/colors';
+import { lmsrCost, lmsrCostCurve, LIQUIDITY_B } from '../../lib/lmsr';
+import { Zap } from 'lucide-react';
 
-export function DepthChartPanel() {
-  const orderBook = useOrderBook();
+// ── Types ───────────────────────────────────────────────────────────────
+
+interface ImpactCurveChartProps {
+  currentPrice: number;
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function DepthChartPanel({ currentPrice }: ImpactCurveChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [size, setSize] = useState({ width: 800, height: 320 });
+  const [size, setSize] = useState({ width: 800, height: 280 });
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
+  // Current probability derived from price
+  const currentProb = Math.min(Math.max(currentPrice / 100, 0.01), 0.99);
+  const probPercent = (currentProb * 100).toFixed(1);
+
+  // Generate curve data
+  const curveData = useMemo(() => lmsrCostCurve(currentProb), [currentProb]);
+  const maxCost = useMemo(() => Math.max(...curveData.map((p) => p.cost), 1), [curveData]);
+
+  // Cost for the calculator strip (+5% move)
+  const calcTarget = Math.min(currentProb + 0.05, 0.98);
+  const calcCost = lmsrCost(currentProb, calcTarget, LIQUIDITY_B);
+
+  // ── Resize observer ─────────────────────────────────────────────────
   useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
     const update = () => {
-      if (!containerRef.current) return;
-      const rect = containerRef.current.getBoundingClientRect();
-      setSize({ width: rect.width, height: rect.height });
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        setSize({ width: rect.width, height: rect.height });
+      }
     };
     update();
-    window.addEventListener('resize', update);
-    return () => window.removeEventListener('resize', update);
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
-  const { bidsCum, asksCum, xMin, xMax, yMax } = useMemo(() => {
-    if (!orderBook) {
-      return {
-        bidsCum: [] as Array<{ price: number; total: number }>,
-        asksCum: [] as Array<{ price: number; total: number }>,
-        xMin: 0,
-        xMax: 1,
-        yMax: 1,
-      };
-    }
-
-    const bids = [...orderBook.bids].sort((a, b) => a.price - b.price);
-    const asks = [...orderBook.asks].sort((a, b) => a.price - b.price);
-
-    const bidsCum: Array<{ price: number; total: number }> = bids.map((b) => ({ price: b.price, total: b.total }));
-    const asksCum: Array<{ price: number; total: number }> = asks.map((a) => ({ price: a.price, total: a.total }));
-
-    const prices = [...bidsCum.map((p) => p.price), ...asksCum.map((p) => p.price)];
-    const xMin = Math.min(...prices);
-    const xMax = Math.max(...prices);
-
-    const yMax = Math.max(
-      bidsCum.length ? bidsCum[bidsCum.length - 1].total : 0,
-      asksCum.length ? asksCum[asksCum.length - 1].total : 0,
-      1
-    );
-
-    return { bidsCum, asksCum, xMin, xMax, yMax };
-  }, [orderBook]);
-
+  // ── Chart geometry ──────────────────────────────────────────────────
   const chart = useMemo(() => {
-    const width = size.width;
-    const height = size.height;
-    const pad = { l: 48, r: 16, t: 24, b: 24 }; // Increased left padding for labels, top for legend space
+    const { width, height } = size;
+    const pad = { l: 56, r: 20, t: 16, b: 32 };
     const w = Math.max(1, width - pad.l - pad.r);
     const h = Math.max(1, height - pad.t - pad.b);
+
+    const xMin = curveData[0]?.targetProb ?? 0;
+    const xMax = curveData[curveData.length - 1]?.targetProb ?? 1;
+    const yMax = maxCost * 1.1; // 10% headroom
+
+    const xScale = (prob: number) => pad.l + ((prob - xMin) / Math.max(1e-9, xMax - xMin)) * w;
+    const yScale = (cost: number) => pad.t + (1 - cost / yMax) * h;
     const yBottom = pad.t + h;
 
-    const xScale = (p: number) => pad.l + ((p - xMin) / Math.max(1e-9, xMax - xMin)) * w;
-    const yScale = (v: number) => pad.t + (1 - v / yMax) * h;
+    // Build SVG path
+    const curvePath = curveData
+      .map((pt, i) => `${i === 0 ? 'M' : 'L'} ${xScale(pt.targetProb).toFixed(2)} ${yScale(pt.cost).toFixed(2)}`)
+      .join(' ');
 
-    const toPathStep = (pts: Array<{ price: number; total: number }>) => {
-      if (pts.length === 0) return '';
-      let d = `M ${xScale(pts[0].price)} ${yScale(pts[0].total)}`;
-      for (let i = 1; i < pts.length; i++) {
-        const prev = pts[i - 1];
-        const cur = pts[i];
-        d += ` L ${xScale(cur.price)} ${yScale(prev.total)}`;
-        d += ` L ${xScale(cur.price)} ${yScale(cur.total)}`;
-      }
-      return d;
-    };
-
-    const bidsPath = toPathStep(bidsCum);
-    const asksPath = toPathStep(asksCum);
-
-    const bidsFill = bidsCum.length > 0 
-      ? `${bidsPath} L ${xScale(bidsCum[bidsCum.length - 1].price)} ${yBottom} L ${xScale(bidsCum[0].price)} ${yBottom} Z`
-      : '';
-    
-    const asksFill = asksCum.length > 0
-      ? `${asksPath} L ${xScale(asksCum[asksCum.length - 1].price)} ${yBottom} L ${xScale(asksCum[0].price)} ${yBottom} Z`
+    // Fill path (closed to bottom)
+    const fillPath = curveData.length > 0
+      ? `${curvePath} L ${xScale(curveData[curveData.length - 1].targetProb).toFixed(2)} ${yBottom} L ${xScale(curveData[0].targetProb).toFixed(2)} ${yBottom} Z`
       : '';
 
-    const gridLines = Array.from({ length: 5 }, (_, i) => i + 1).map((i) => {
-      const y = pad.t + (i / 5) * h;
-      return y;
+    // Grid — 4 horizontal lines
+    const hGridLines = Array.from({ length: 4 }, (_, i) => {
+      const val = (yMax / 5) * (i + 1);
+      return { y: yScale(val), label: `$${val.toFixed(0)}` };
     });
 
-    const xLabels = [xMin, (xMin + xMax) / 2, xMax].map((p) => ({ p, x: xScale(p) }));
-    const yLabels = [0, yMax / 4, yMax / 2, yMax * 0.75, yMax].map((v) => ({ v, y: yScale(v) }));
+    // Grid — 5 vertical lines (probability ticks)
+    const xRange = xMax - xMin;
+    const vGridLines = Array.from({ length: 5 }, (_, i) => {
+      const prob = xMin + (xRange / 6) * (i + 1);
+      return { x: xScale(prob), label: `${(prob * 100).toFixed(0)}%` };
+    });
 
-    const mid = orderBook?.midPrice ?? (xMin + xMax) / 2;
-    const midX = xScale(mid);
+    // X-axis labels (edges + centre)
+    const xLabels = [
+      { prob: xMin, x: xScale(xMin), anchor: 'start' as const },
+      { prob: (xMin + xMax) / 2, x: xScale((xMin + xMax) / 2), anchor: 'middle' as const },
+      { prob: xMax, x: xScale(xMax), anchor: 'end' as const },
+    ];
 
-    return { bidsPath, asksPath, bidsFill, asksFill, gridLines, xLabels, yLabels, midX, pad, w, h };
-  }, [size, bidsCum, asksCum, xMin, xMax, yMax, orderBook]);
+    // Current probability marker
+    const currentX = xScale(currentProb);
+
+    return { pad, w, h, yBottom, curvePath, fillPath, hGridLines, vGridLines, xLabels, currentX, xScale, yScale, xMin, xMax, yMax };
+  }, [size, curveData, maxCost, currentProb]);
+
+  // ── Hover handler ───────────────────────────────────────────────────
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+
+      // Find nearest curve point
+      let closest = 0;
+      let closestDist = Infinity;
+      for (let i = 0; i < curveData.length; i++) {
+        const px = chart.xScale(curveData[i].targetProb);
+        const dist = Math.abs(px - mouseX);
+        if (dist < closestDist) {
+          closestDist = dist;
+          closest = i;
+        }
+      }
+      setHoverIdx(closestDist < 40 ? closest : null);
+    },
+    [curveData, chart],
+  );
+
+  const handleMouseLeave = useCallback(() => setHoverIdx(null), []);
+
+  // Hover point data
+  const hoverPoint = hoverIdx !== null ? curveData[hoverIdx] : null;
+  const hoverX = hoverPoint ? chart.xScale(hoverPoint.targetProb) : 0;
+  const hoverY = hoverPoint ? chart.yScale(hoverPoint.cost) : 0;
 
   return (
-    <div className="chart-container flex flex-col gap-4 min-h-[300px]" style={{ flex: '1 1 400px' }}>
+    <div className="chart-container flex flex-col gap-3 min-h-[300px]" style={{ flex: '1 1 400px' }}>
+      {/* ── Header ─────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between flex-shrink-0">
-        <h3 className="text-sm font-semibold text-terminal-text uppercase tracking-wide">Depth Chart</h3>
-        {orderBook ? (
-          <span className="text-[10px] font-mono text-terminal-text-muted">
-            Spread ${orderBook.spread.toFixed(3)} ({orderBook.spreadPercent.toFixed(2)}%)
-          </span>
-        ) : null}
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-terminal-text uppercase tracking-wide">
+            Impact Curve
+          </h3>
+          <span className="chip chip-info text-[9px]">LMSR</span>
+        </div>
+        <span className="text-[10px] font-mono tabular-nums text-terminal-text-muted">
+          Current: {probPercent}% &middot; b={LIQUIDITY_B}
+        </span>
       </div>
 
+      {/* ── SVG Chart ──────────────────────────────────────────────── */}
       <div ref={containerRef} className="flex-1 min-h-0 relative">
-        {!orderBook ? (
-          <div className="flex items-center justify-center h-full text-terminal-text-muted text-xs">Loading depth...</div>
-        ) : (
-          <svg width="100%" height="100%" className="overflow-visible">
-            <defs>
-              <linearGradient id="gradBids" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={CHART.BID} stopOpacity="0.2" />
-                <stop offset="100%" stopColor={CHART.BID} stopOpacity="0.05" />
-              </linearGradient>
-              <linearGradient id="gradAsks" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={CHART.ASK} stopOpacity="0.2" />
-                <stop offset="100%" stopColor={CHART.ASK} stopOpacity="0.05" />
-              </linearGradient>
-            </defs>
+        <svg
+          width="100%"
+          height="100%"
+          className="overflow-visible"
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+        >
+          <defs>
+            <linearGradient id="gradImpactCurve" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={CHART.COST_CURVE} stopOpacity="0.12" />
+              <stop offset="100%" stopColor={CHART.COST_CURVE} stopOpacity="0.02" />
+            </linearGradient>
+          </defs>
 
-            {/* Legend */}
-            <g transform={`translate(${size.width - 100}, ${chart.pad.t - 15})`}>
-              <rect width="10" height="10" fill={CHART.BID} fillOpacity="0.8" rx="2" />
-              <text x="14" y="9" className="fill-terminal-text text-[10px] font-medium">Bids</text>
-              
-              <rect x="45" width="10" height="10" fill={CHART.ASK} fillOpacity="0.8" rx="2" />
-              <text x="59" y="9" className="fill-terminal-text text-[10px] font-medium">Asks</text>
-            </g>
-
-            {/* grid */}
-            {chart.gridLines.map((y, i) => (
+          {/* Horizontal grid */}
+          {chart.hGridLines.map((line, i) => (
+            <g key={`hg-${i}`}>
               <line
-                key={i}
                 x1={chart.pad.l}
                 x2={chart.pad.l + chart.w}
-                y1={y}
-                y2={y}
+                y1={line.y}
+                y2={line.y}
                 stroke={CHART.GRID}
                 strokeWidth={1}
                 strokeDasharray="4 4"
                 strokeOpacity={0.4}
               />
-            ))}
-            
-            {/* Axis Titles */}
-            <text 
-              x={chart.pad.l - 40} 
-              y={chart.pad.t + chart.h / 2} 
-              transform={`rotate(-90, ${chart.pad.l - 40}, ${chart.pad.t + chart.h / 2})`}
-              className="fill-terminal-text-muted text-[10px] font-mono opacity-50"
-              textAnchor="middle"
-            >
-              Cumulative Vol
-            </text>
-
-            {/* axes labels */}
-            {chart.yLabels.map((l, i) => (
               <text
-                key={`yl-${i}`}
                 x={chart.pad.l - 8}
-                y={l.y + 3}
-                className="fill-terminal-text-muted text-[10px] font-mono"
+                y={line.y + 3}
                 textAnchor="end"
-              >
-                {(l.v / 1000).toFixed(1)}K
-              </text>
-            ))}
-            {chart.xLabels.map((l, i) => (
-              <text
-                key={`xl-${i}`}
-                x={l.x}
-                y={size.height - 4}
-                textAnchor={i === 0 ? 'start' : i === 2 ? 'end' : 'middle'}
                 className="fill-terminal-text-muted text-[10px] font-mono"
               >
-                ${l.p.toFixed(2)}
+                {line.label}
               </text>
-            ))}
+            </g>
+          ))}
 
-            {/* mid line */}
+          {/* Vertical grid */}
+          {chart.vGridLines.map((line, i) => (
             <line
-              x1={chart.midX}
-              x2={chart.midX}
+              key={`vg-${i}`}
+              x1={line.x}
+              x2={line.x}
               y1={chart.pad.t}
-              y2={chart.pad.t + chart.h}
-              className="stroke-status-info"
-              strokeWidth={1.5}
+              y2={chart.yBottom}
+              stroke={CHART.GRID}
+              strokeWidth={1}
               strokeDasharray="4 4"
-              strokeOpacity={0.6}
+              strokeOpacity={0.25}
             />
-            {/* Mid Label */}
+          ))}
+
+          {/* X-axis labels */}
+          {chart.xLabels.map((l, i) => (
             <text
-              x={chart.midX}
-              y={chart.pad.t - 5}
-              textAnchor="middle"
-              className="fill-status-info text-[10px] font-mono font-semibold"
+              key={`xl-${i}`}
+              x={l.x}
+              y={chart.yBottom + 18}
+              textAnchor={l.anchor}
+              className="fill-terminal-text-muted text-[10px] font-mono"
             >
-              Mid
+              {(l.prob * 100).toFixed(0)}%
             </text>
+          ))}
 
-            {/* areas */}
-            <path d={chart.bidsFill} fill="url(#gradBids)" />
-            <path d={chart.asksFill} fill="url(#gradAsks)" />
+          {/* Y-axis title */}
+          <text
+            x={chart.pad.l - 44}
+            y={chart.pad.t + chart.h / 2}
+            transform={`rotate(-90, ${chart.pad.l - 44}, ${chart.pad.t + chart.h / 2})`}
+            className="fill-terminal-text-muted text-[10px] font-mono opacity-50"
+            textAnchor="middle"
+          >
+            Cost ($)
+          </text>
 
-            {/* lines */}
-            <path d={chart.bidsPath} fill="none" stroke={CHART.BID} strokeWidth={2} strokeLinejoin="round" />
-            <path d={chart.asksPath} fill="none" stroke={CHART.ASK} strokeWidth={2} strokeLinejoin="round" />
-          </svg>
-        )}
+          {/* X-axis title */}
+          <text
+            x={chart.pad.l + chart.w / 2}
+            y={chart.yBottom + 28}
+            className="fill-terminal-text-muted text-[10px] font-mono opacity-50"
+            textAnchor="middle"
+          >
+            Target Probability
+          </text>
+
+          {/* Filled area under curve */}
+          <path d={chart.fillPath} fill="url(#gradImpactCurve)" />
+
+          {/* Curve line */}
+          <path
+            d={chart.curvePath}
+            fill="none"
+            stroke={CHART.COST_CURVE}
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+
+          {/* Current probability vertical marker */}
+          <line
+            x1={chart.currentX}
+            x2={chart.currentX}
+            y1={chart.pad.t}
+            y2={chart.yBottom}
+            className="stroke-status-info"
+            strokeWidth={1.5}
+            strokeDasharray="4 4"
+            strokeOpacity={0.6}
+          />
+          <text
+            x={chart.currentX}
+            y={chart.pad.t - 4}
+            textAnchor="middle"
+            className="fill-status-info text-[10px] font-mono font-semibold"
+          >
+            Current
+          </text>
+
+          {/* Hover crosshair + dot */}
+          {hoverPoint && (
+            <>
+              {/* Vertical crosshair */}
+              <line
+                x1={hoverX}
+                x2={hoverX}
+                y1={chart.pad.t}
+                y2={chart.yBottom}
+                stroke={CHART.COST_CURVE}
+                strokeWidth={1}
+                strokeDasharray="2 2"
+                strokeOpacity={0.4}
+              />
+              {/* Horizontal crosshair */}
+              <line
+                x1={chart.pad.l}
+                x2={chart.pad.l + chart.w}
+                y1={hoverY}
+                y2={hoverY}
+                stroke={CHART.COST_CURVE}
+                strokeWidth={1}
+                strokeDasharray="2 2"
+                strokeOpacity={0.4}
+              />
+              {/* Dot */}
+              <circle
+                cx={hoverX}
+                cy={hoverY}
+                r={4}
+                fill={CHART.COST_CURVE}
+                stroke="#030305"
+                strokeWidth={2}
+              />
+              {/* Tooltip background */}
+              <rect
+                x={hoverX + (hoverX > size.width / 2 ? -130 : 12)}
+                y={hoverY - 24}
+                width={118}
+                height={26}
+                rx={6}
+                fill="#10141A"
+                fillOpacity={0.95}
+                stroke={CHART.COST_CURVE}
+                strokeWidth={1}
+                strokeOpacity={0.3}
+              />
+              {/* Tooltip text */}
+              <text
+                x={hoverX + (hoverX > size.width / 2 ? -71 : 71)}
+                y={hoverY - 7}
+                textAnchor="middle"
+                className="text-[11px] font-mono font-semibold"
+                fill={CHART.COST_CURVE}
+              >
+                &rarr; {(hoverPoint.targetProb * 100).toFixed(1)}% | ${hoverPoint.cost.toFixed(2)}
+              </text>
+            </>
+          )}
+        </svg>
+      </div>
+
+      {/* ── Cost-to-move calculator strip ──────────────────────────── */}
+      <div className="flex-shrink-0 bg-terminal-card/50 border border-terminal-border/50 rounded-lg px-4 py-2.5 flex items-center gap-3">
+        <Zap className="w-3.5 h-3.5 text-echelon-amber flex-shrink-0" />
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="data-label">To move</span>
+          <span className="font-mono tabular-nums text-echelon-cyan font-semibold">{probPercent}%</span>
+          <span className="text-terminal-text-muted">&rarr;</span>
+          <span className="font-mono tabular-nums text-echelon-green font-semibold">{(calcTarget * 100).toFixed(1)}%</span>
+          <span className="data-label">costs</span>
+          <span className="font-mono tabular-nums text-terminal-text font-bold text-sm">${calcCost.toFixed(2)}</span>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/blackbox/ImpactCostPanel.tsx
+++ b/frontend/src/components/blackbox/ImpactCostPanel.tsx
@@ -1,31 +1,17 @@
 /**
  * CFPM / LMSR Impact & Cost Panel
  *
- * Replaces the traditional order book with a cost-function prediction market
- * (CFPM) panel powered by LMSR (Logarithmic Market Scoring Rule).
+ * Right-side panel showing market probability, liquidity parameters,
+ * and an impact ladder powered by LMSR (Logarithmic Market Scoring Rule).
  * All values are demo/mock — no backend required.
  */
 
-import { Activity, Zap, TrendingUp, ArrowRight } from 'lucide-react';
+import { Activity, TrendingUp } from 'lucide-react';
 import { clsx } from 'clsx';
+import { lmsrCost, LIQUIDITY_B, NUM_OUTCOMES, WORST_CASE_LOSS } from '../../lib/lmsr';
 
 interface ImpactCostPanelProps {
   currentPrice: number;
-}
-
-// ── Demo LMSR parameters ────────────────────────────────────────────────
-const LIQUIDITY_B = 142.5;
-const NUM_OUTCOMES = 2;
-const WORST_CASE_LOSS = LIQUIDITY_B * Math.log(NUM_OUTCOMES);
-
-// LMSR cost function: C(q) = b * ln(sum(exp(q_i / b)))
-// For binary market, cost to move probability from p1 to p2:
-// cost = b * ln(exp(q_yes_new/b) + exp(q_no_new/b)) - b * ln(exp(q_yes_old/b) + exp(q_no_old/b))
-function lmsrCost(pFrom: number, pTo: number, b: number): number {
-  // Simplified binary LMSR cost approximation
-  const qFrom = Math.log(pFrom / (1 - pFrom));
-  const qTo = Math.log(pTo / (1 - pTo));
-  return Math.abs(b * (qTo - qFrom)) * 0.42; // Scaled for demo realism
 }
 
 // Impact ladder entries
@@ -58,7 +44,7 @@ export function ImpactCostPanel({ currentPrice }: ImpactCostPanelProps) {
         {/* ── Instant Price ────────────────────────────────────── */}
         <div className="bg-terminal-card rounded-xl p-4 border border-terminal-border">
           <div className="flex items-center justify-between mb-3">
-            <span className="data-label">Instant Probability</span>
+            <span className="data-label">Market Probability</span>
             <span className="chip chip-success text-[9px]">CFPM</span>
           </div>
           <div className="flex items-baseline gap-2">
@@ -83,6 +69,7 @@ export function ImpactCostPanel({ currentPrice }: ImpactCostPanelProps) {
             <div className="metric-block bg-terminal-card/50 rounded-lg p-3 border border-terminal-border/50">
               <span className="metric-label">Depth (b)</span>
               <span className="metric-value text-echelon-cyan">{LIQUIDITY_B.toFixed(1)}</span>
+              <span className="text-[10px] text-terminal-text-muted mt-1">higher b = deeper liquidity</span>
             </div>
             <div className="metric-block bg-terminal-card/50 rounded-lg p-3 border border-terminal-border/50">
               <span className="metric-label">Max Loss</span>
@@ -102,29 +89,6 @@ export function ImpactCostPanel({ currentPrice }: ImpactCostPanelProps) {
               <span className="text-xs font-mono tabular-nums text-terminal-text">
                 {LIQUIDITY_B} &times; ln({NUM_OUTCOMES}) = ${WORST_CASE_LOSS.toFixed(2)}
               </span>
-            </div>
-          </div>
-        </div>
-
-        {/* ── Cost Calculator ──────────────────────────────────── */}
-        <div className="space-y-2">
-          <span className="section-title-accented">Cost Calculator</span>
-
-          <div className="bg-terminal-card rounded-xl p-4 border border-terminal-border">
-            <div className="flex items-center gap-2 text-sm text-terminal-text-secondary mb-3">
-              <span className="text-terminal-text-muted">Move probability</span>
-              <span className="font-mono tabular-nums text-echelon-cyan font-semibold">{probPercent}%</span>
-              <ArrowRight className="w-3 h-3 text-terminal-text-muted" />
-              <span className="font-mono tabular-nums text-echelon-green font-semibold">
-                {(currentProb * 100 + 5).toFixed(1)}%
-              </span>
-            </div>
-            <div className="flex items-baseline gap-2">
-              <Zap className="w-4 h-4 text-echelon-amber" />
-              <span className="text-xl font-mono font-bold tabular-nums text-terminal-text">
-                ${lmsrCost(currentProb, Math.min(currentProb + 0.05, 0.99), LIQUIDITY_B).toFixed(2)}
-              </span>
-              <span className="text-xs text-terminal-text-muted">estimated cost</span>
             </div>
           </div>
         </div>

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -6,4 +6,5 @@ export const CHART = {
   BLUE: '#3B82F6',     // echelon-blue
   GRID: 'rgba(255,255,255,0.06)',
   LABEL: '#6B7280',    // terminal-text-muted
+  COST_CURVE: '#22D3EE', // echelon-cyan — impact curve line
 } as const;

--- a/frontend/src/lib/lmsr.ts
+++ b/frontend/src/lib/lmsr.ts
@@ -1,0 +1,57 @@
+/**
+ * LMSR (Logarithmic Market Scoring Rule) — shared math
+ *
+ * Used by ImpactCostPanel and DepthChartPanel (Impact Curve).
+ * All values are demo/mock — no backend required.
+ */
+
+// ── Parameters ──────────────────────────────────────────────────────────
+export const LIQUIDITY_B = 142.5;
+export const NUM_OUTCOMES = 2;
+export const WORST_CASE_LOSS = LIQUIDITY_B * Math.log(NUM_OUTCOMES);
+
+// ── Cost function ───────────────────────────────────────────────────────
+
+/**
+ * Binary LMSR cost to move probability from `pFrom` to `pTo`.
+ *
+ * Uses a simplified log-odds approach scaled for demo realism.
+ */
+export function lmsrCost(
+  pFrom: number,
+  pTo: number,
+  b: number = LIQUIDITY_B,
+): number {
+  const qFrom = Math.log(pFrom / (1 - pFrom));
+  const qTo = Math.log(pTo / (1 - pTo));
+  return Math.abs(b * (qTo - qFrom)) * 0.42; // Scaled for demo realism
+}
+
+// ── Curve generator ─────────────────────────────────────────────────────
+
+export interface CurvePoint {
+  targetProb: number;
+  cost: number;
+}
+
+/**
+ * Generate an array of `{ targetProb, cost }` points for charting the
+ * cost-to-move curve centred on `currentProb`.
+ */
+export function lmsrCostCurve(
+  currentProb: number,
+  steps: number = 50,
+  maxDelta: number = 0.40,
+  b: number = LIQUIDITY_B,
+): CurvePoint[] {
+  const points: CurvePoint[] = [];
+  const pMin = Math.max(0.02, currentProb - maxDelta);
+  const pMax = Math.min(0.98, currentProb + maxDelta);
+
+  for (let i = 0; i <= steps; i++) {
+    const targetProb = pMin + (i / steps) * (pMax - pMin);
+    const cost = lmsrCost(currentProb, targetProb, b);
+    points.push({ targetProb, cost });
+  }
+  return points;
+}

--- a/frontend/src/pages/BlackboxPage.tsx
+++ b/frontend/src/pages/BlackboxPage.tsx
@@ -98,7 +98,7 @@ export function BlackboxPage() {
           />
         );
       case 'depth':
-        return <DepthChartPanel />;
+        return <DepthChartPanel currentPrice={currentPrice} />;
       case 'vol':
         return <VolumeProfilePanel />;
       case 'heatmap':


### PR DESCRIPTION
Rewrites DepthChartPanel as a true CFPM/LMSR cost-to-move visualization with interactive hover tooltips and a calculator strip. Extracts shared LMSR math into src/lib/lmsr.ts and tightens ImpactCostPanel for clarity.